### PR TITLE
Static Class Prototype

### DIFF
--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Interop\Async\EventLoop;
+
+final class EventLoop
+{
+    /**
+     * @var EventLoopDriver
+     */
+    private static $driver = null;
+
+    /**
+     * Execute a callback within the scope of an event loop driver.
+     *
+     * @param callable $callback The callback to execute
+     * @param EventLoopDriver $driver The event loop driver
+     *
+     * @return void
+     */
+    public static function execute(callable $callback, EventLoopDriver $driver)
+    {
+        $previousDriver = self::$driver;
+
+        self::$driver = $driver;
+
+        try {
+            $callback();
+
+            self::$driver->run();
+        } finally {
+            self::$driver = $previousDriver;
+        }
+    }
+
+    /**
+     * Stop the event loop.
+     * 
+     * @return void
+     */
+    public static function stop()
+    {
+        self::$driver->stop();
+    }
+
+    /**
+     * Defer the execution of a callback.
+     * 
+     * @param callable $callback The callback to defer.
+     * 
+     * @return string An identifier that can be used to cancel, enable or disable the event.
+     */
+    public static function defer(callable $callback)
+    {
+        return self::$driver->defer($callback);
+    }
+
+    /**
+     * Delay the execution of a callback. The time delay is approximate and accuracy is not guaranteed.
+     * 
+     * @param callable $callback The callback to delay.
+     * @param float $time The amount of time, in seconds, to delay the execution for.
+     * 
+     * @return string An identifier that can be used to cancel, enable or disable the event.
+     */
+    public static function delay(callable $callback, float $time)
+    {
+        return self::$driver->delay($callback, $time);
+    }
+
+    /**
+     * Repeatedly execute a callback. The interval between executions is approximate and accuracy is not guaranteed.
+     * 
+     * @param callable $callback The callback to repeat.
+     * @param float $interval The time interval, in seconds, to wait between executions.
+     * 
+     * @return string An identifier that can be used to cancel, enable or disable the event.
+     */
+    public static function repeat(callable $callback, float $interval)
+    {
+        return self::$driver->repeat($callback, $interval);
+    }
+
+    /**
+     * Execute a callback when a stream resource becomes readable.
+     * 
+     * @param resource $stream The stream to monitor.
+     * @param callable $callback The callback to execute.
+     * 
+     * @return string An identifier that can be used to cancel, enable or disable the event.
+     */
+    public static function onReadable($stream, callable $callback)
+    {
+        return self::$driver->onReadable($stream, $callback);
+    }
+
+    /**
+     * Execute a callback when a stream resource becomes writable.
+     * 
+     * @param resource $stream The stream to monitor.
+     * @param callable $callback The callback to execute.
+     * 
+     * @return string An identifier that can be used to cancel, enable or disable the event.
+     */
+    public function onWritable($stream, callable $callback)
+    {
+        return self::$driver->onWritable($stream, $callback);
+    }
+
+    /**
+     * Execute a callback when a signal is received.
+     * 
+     * @param int $signo The signal number to monitor.
+     * @param callable $callback The callback to execute.
+     * 
+     * @return string An identifier that can be used to cancel, enable or disable the event.
+     */
+    public function onSignal(int $signo, callable $callback)
+    {
+        return self::$driver->onSignal($signo, $callback);
+    }
+
+    /**
+     * Execute a callback when an error occurs.
+     * 
+     * @param callable $callback The callback to execute.
+     * 
+     * @return string An identifier that can be used to cancel, enable or disable the event.
+     */
+    public function onError(callable $callback)
+    {
+        return self::$driver->onError($callback);
+    }
+
+    /**
+     * Enable an event.
+     * 
+     * @param string $eventIdentifier The event identifier.
+     * 
+     * @return void
+     */
+    public function enable(string $eventIdentifier)
+    {
+        self::$driver->enable($eventIdentifier);
+    }
+
+    /**
+     * Disable an event.
+     * 
+     * @param string $eventIdentifier The event identifier.
+     * 
+     * @return void
+     */
+    public function disable(string $eventIdentifier)
+    {
+        self::$driver->disable($eventIdentifier);
+    }
+
+    /**
+     * Cancel an event.
+     * 
+     * @param string $eventIdentifier The event identifier.
+     * 
+     * @return void
+     */
+    public function cancel(string $eventIdentifier)
+    {
+        self::$driver->cancel($eventIdentifier);
+    }
+
+    /**
+     * Reference an event.
+     * 
+     * This will keep the event loop alive whilst the event is still being monitored. Events have this state by default.
+     * 
+     * @param string $eventIdentifier The event identifier.
+     * 
+     * @return void
+     */
+    public function reference(string $eventIdentifier)
+    {
+        self::$driver->reference($eventIdentifier);
+    }
+
+    /**
+     * Unreference an event.
+     * 
+     * The event loop should exit the run method when only unreferenced events are still being monitored. Events are all
+     * referenced by default.
+     * 
+     * @param string $eventIdentifier The event identifier.
+     * 
+     * @return void
+     */
+    public function unreference(string $eventIdentifier)
+    {
+        self::$driver->unreference($eventIdentifier);
+    }
+
+    /**
+     * Disable construction as this is a static class.
+     */
+    public function __construct()
+    {
+        throw new \LogicException('This class is a static class and should not be initialized');
+    }
+}

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -123,7 +123,7 @@ final class EventLoop
      * 
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function onWritable($stream, callable $callback)
+    public static function onWritable($stream, callable $callback)
     {
         self::inScope();
 
@@ -138,7 +138,7 @@ final class EventLoop
      * 
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function onSignal(int $signo, callable $callback)
+    public static function onSignal(int $signo, callable $callback)
     {
         self::inScope();
 
@@ -152,7 +152,7 @@ final class EventLoop
      * 
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function onError(callable $callback)
+    public static function onError(callable $callback)
     {
         self::inScope();
 
@@ -166,7 +166,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public function enable(string $eventIdentifier)
+    public static function enable(string $eventIdentifier)
     {
         self::inScope();
 
@@ -180,7 +180,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public function disable(string $eventIdentifier)
+    public static function disable(string $eventIdentifier)
     {
         self::inScope();
 
@@ -194,7 +194,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public function cancel(string $eventIdentifier)
+    public static function cancel(string $eventIdentifier)
     {
         self::inScope();
 
@@ -210,7 +210,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public function reference(string $eventIdentifier)
+    public static function reference(string $eventIdentifier)
     {
         self::inScope();
 
@@ -227,7 +227,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public function unreference(string $eventIdentifier)
+    public static function unreference(string $eventIdentifier)
     {
         self::inScope();
 

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -39,7 +39,9 @@ final class EventLoop
      */
     public static function get()
     {
-        self::inScope();
+        if (null === self::$driver) {
+            throw new \RuntimeException('Not within the scope of an event loop driver');
+        }
 
         return self::$driver;
     }
@@ -51,9 +53,7 @@ final class EventLoop
      */
     public static function stop()
     {
-        self::inScope();
-
-        self::$driver->stop();
+        self::get()->stop();
     }
 
     /**
@@ -65,9 +65,7 @@ final class EventLoop
      */
     public static function defer(callable $callback)
     {
-        self::inScope();
-
-        return self::$driver->defer($callback);
+        return self::get()->defer($callback);
     }
 
     /**
@@ -80,9 +78,7 @@ final class EventLoop
      */
     public static function delay(callable $callback, float $time)
     {
-        self::inScope();
-
-        return self::$driver->delay($callback, $time);
+        return self::get()->delay($callback, $time);
     }
 
     /**
@@ -95,9 +91,7 @@ final class EventLoop
      */
     public static function repeat(callable $callback, float $interval)
     {
-        self::inScope();
-
-        return self::$driver->repeat($callback, $interval);
+        return self::get()->repeat($callback, $interval);
     }
 
     /**
@@ -110,9 +104,7 @@ final class EventLoop
      */
     public static function onReadable($stream, callable $callback)
     {
-        self::inScope();
-
-        return self::$driver->onReadable($stream, $callback);
+        return self::get()->onReadable($stream, $callback);
     }
 
     /**
@@ -125,9 +117,7 @@ final class EventLoop
      */
     public static function onWritable($stream, callable $callback)
     {
-        self::inScope();
-
-        return self::$driver->onWritable($stream, $callback);
+        return self::get()->onWritable($stream, $callback);
     }
 
     /**
@@ -140,9 +130,7 @@ final class EventLoop
      */
     public static function onSignal(int $signo, callable $callback)
     {
-        self::inScope();
-
-        return self::$driver->onSignal($signo, $callback);
+        return self::get()->onSignal($signo, $callback);
     }
 
     /**
@@ -154,9 +142,7 @@ final class EventLoop
      */
     public static function onError(callable $callback)
     {
-        self::inScope();
-
-        return self::$driver->onError($callback);
+        return self::get()->onError($callback);
     }
 
     /**
@@ -168,9 +154,7 @@ final class EventLoop
      */
     public static function enable(string $eventIdentifier)
     {
-        self::inScope();
-
-        self::$driver->enable($eventIdentifier);
+        self::get()->enable($eventIdentifier);
     }
 
     /**
@@ -182,9 +166,7 @@ final class EventLoop
      */
     public static function disable(string $eventIdentifier)
     {
-        self::inScope();
-
-        self::$driver->disable($eventIdentifier);
+        self::get()->disable($eventIdentifier);
     }
 
     /**
@@ -196,9 +178,7 @@ final class EventLoop
      */
     public static function cancel(string $eventIdentifier)
     {
-        self::inScope();
-
-        self::$driver->cancel($eventIdentifier);
+        self::get()->cancel($eventIdentifier);
     }
 
     /**
@@ -212,9 +192,7 @@ final class EventLoop
      */
     public static function reference(string $eventIdentifier)
     {
-        self::inScope();
-
-        self::$driver->reference($eventIdentifier);
+        self::get()->reference($eventIdentifier);
     }
 
     /**
@@ -229,21 +207,7 @@ final class EventLoop
      */
     public static function unreference(string $eventIdentifier)
     {
-        self::inScope();
-
-        self::$driver->unreference($eventIdentifier);
-    }
-
-    /**
-     * Validate that the event loop is currently within the scope of a driver.
-     * 
-     * @return void
-     */
-    private static function inScope()
-    {
-        if (null === self::$driver) {
-            throw new \RuntimeException('Not within the scope of an event loop driver');
-        }
+        self::get()->unreference($eventIdentifier);
     }
 
     /**

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -33,12 +33,26 @@ final class EventLoop
     }
 
     /**
+     * Retrieve the event loop driver that is in scope.
+     * 
+     * @return EventLoopDriver
+     */
+    public static function get()
+    {
+        self::inScope();
+
+        return self::$driver;
+    }
+
+    /**
      * Stop the event loop.
      * 
      * @return void
      */
     public static function stop()
     {
+        self::inScope();
+
         self::$driver->stop();
     }
 
@@ -51,6 +65,8 @@ final class EventLoop
      */
     public static function defer(callable $callback)
     {
+        self::inScope();
+
         return self::$driver->defer($callback);
     }
 
@@ -64,6 +80,8 @@ final class EventLoop
      */
     public static function delay(callable $callback, float $time)
     {
+        self::inScope();
+
         return self::$driver->delay($callback, $time);
     }
 
@@ -77,6 +95,8 @@ final class EventLoop
      */
     public static function repeat(callable $callback, float $interval)
     {
+        self::inScope();
+
         return self::$driver->repeat($callback, $interval);
     }
 
@@ -90,6 +110,8 @@ final class EventLoop
      */
     public static function onReadable($stream, callable $callback)
     {
+        self::inScope();
+
         return self::$driver->onReadable($stream, $callback);
     }
 
@@ -103,6 +125,8 @@ final class EventLoop
      */
     public function onWritable($stream, callable $callback)
     {
+        self::inScope();
+
         return self::$driver->onWritable($stream, $callback);
     }
 
@@ -116,6 +140,8 @@ final class EventLoop
      */
     public function onSignal(int $signo, callable $callback)
     {
+        self::inScope();
+
         return self::$driver->onSignal($signo, $callback);
     }
 
@@ -128,6 +154,8 @@ final class EventLoop
      */
     public function onError(callable $callback)
     {
+        self::inScope();
+
         return self::$driver->onError($callback);
     }
 
@@ -140,6 +168,8 @@ final class EventLoop
      */
     public function enable(string $eventIdentifier)
     {
+        self::inScope();
+
         self::$driver->enable($eventIdentifier);
     }
 
@@ -152,6 +182,8 @@ final class EventLoop
      */
     public function disable(string $eventIdentifier)
     {
+        self::inScope();
+
         self::$driver->disable($eventIdentifier);
     }
 
@@ -164,6 +196,8 @@ final class EventLoop
      */
     public function cancel(string $eventIdentifier)
     {
+        self::inScope();
+
         self::$driver->cancel($eventIdentifier);
     }
 
@@ -178,6 +212,8 @@ final class EventLoop
      */
     public function reference(string $eventIdentifier)
     {
+        self::inScope();
+
         self::$driver->reference($eventIdentifier);
     }
 
@@ -193,7 +229,21 @@ final class EventLoop
      */
     public function unreference(string $eventIdentifier)
     {
+        self::inScope();
+
         self::$driver->unreference($eventIdentifier);
+    }
+
+    /**
+     * Validate that the event loop is currently within the scope of a driver.
+     * 
+     * @return void
+     */
+    private static function inScope()
+    {
+        if (null === self::$driver) {
+            throw new \RuntimeException('Not within the scope of an event loop driver');
+        }
     }
 
     /**

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -72,7 +72,7 @@ final class EventLoop
      * Delay the execution of a callback. The time delay is approximate and accuracy is not guaranteed.
      * 
      * @param callable $callback The callback to delay.
-     * @param float $time The amount of time, in seconds, to delay the execution for.
+     * @param int $time The amount of time, in milliseconds, to delay the execution for.
      * 
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
@@ -85,7 +85,7 @@ final class EventLoop
      * Repeatedly execute a callback. The interval between executions is approximate and accuracy is not guaranteed.
      * 
      * @param callable $callback The callback to repeat.
-     * @param float $interval The time interval, in seconds, to wait between executions.
+     * @param int $interval The time interval, in milliseconds, to wait between executions.
      * 
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -76,7 +76,7 @@ final class EventLoop
      * 
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function delay(callable $callback, float $time)
+    public static function delay(callable $callback, $time)
     {
         return self::get()->delay($callback, $time);
     }
@@ -89,7 +89,7 @@ final class EventLoop
      * 
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function repeat(callable $callback, float $interval)
+    public static function repeat(callable $callback, $interval)
     {
         return self::get()->repeat($callback, $interval);
     }
@@ -128,7 +128,7 @@ final class EventLoop
      * 
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function onSignal(int $signo, callable $callback)
+    public static function onSignal($signo, callable $callback)
     {
         return self::get()->onSignal($signo, $callback);
     }
@@ -152,7 +152,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public static function enable(string $eventIdentifier)
+    public static function enable($eventIdentifier)
     {
         self::get()->enable($eventIdentifier);
     }
@@ -164,7 +164,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public static function disable(string $eventIdentifier)
+    public static function disable($eventIdentifier)
     {
         self::get()->disable($eventIdentifier);
     }
@@ -176,7 +176,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public static function cancel(string $eventIdentifier)
+    public static function cancel($eventIdentifier)
     {
         self::get()->cancel($eventIdentifier);
     }
@@ -190,7 +190,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public static function reference(string $eventIdentifier)
+    public static function reference($eventIdentifier)
     {
         self::get()->reference($eventIdentifier);
     }
@@ -205,7 +205,7 @@ final class EventLoop
      * 
      * @return void
      */
-    public static function unreference(string $eventIdentifier)
+    public static function unreference($eventIdentifier)
     {
         self::get()->unreference($eventIdentifier);
     }

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -213,8 +213,5 @@ final class EventLoop
     /**
      * Disable construction as this is a static class.
      */
-    public function __construct()
-    {
-        throw new \LogicException('This class is a static class and should not be initialized');
-    }
+    private function __construct() {}
 }


### PR DESCRIPTION
For those not in the know, this follows on from the discussion in #14 and attempts to solve the problem of being able to access the event loop without injecting it as a dependency anywhere.

The solution that I favour discussed in #14 is represented in this PR. I believe it represents a happy medium between injecting the event loop everywhere and global god classes. The life time of an event loop is easily defined by the scope within which it is invoked.

Example usage:

``` php
use Interop\Async\EventLoop;
use AsyncProject\LibEvDriver;

// ...

EventLoop::execute(function () {
    // This callback will be run within the scope of the specified event loop driver

    // ...

    EventLoop::onReadable($inputStream, $inputStreamHandler);
    EventLoop::onWritable($outputStream, $outputStreamHandler);
}, new LibEvDriver());
```
