### PR TITLE
Add LoopDriverFactory

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -54,7 +54,7 @@ final class Loop
     /**
      * Create a new driver if a factory is present, otherwise throw.
      *
-     * @throws \LogicException if no factory is set
+     * @throws \LogicException if no factory is set or no driver returned from factory
      */
     private static function createDriver()
     {
@@ -62,7 +62,13 @@ final class Loop
             throw new \LogicException("Can't create an event loop driver without a factory.");
         }
 
-        return self::$factory->create();
+        $driver = self::$factory->create();
+
+        if (!$driver instanceof LoopDriver) {
+            throw new \LogicException("LoopDriverFactory didn't return a LoopDriver.");
+        }
+
+        return $driver;
     }
 
     /**

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -18,10 +18,12 @@ final class Loop
 
     /**
      * Set the factory to be used to create a driver if none is passed to
-     * self::execute.
+     * self::execute. A default driver will be created if none exists yet
+     * to support synchronous waits in traditional applications.
      */
     public static function setFactory(LoopDriverFactory $factory = null) {
         self::$factory = $factory;
+        self::$driver = self::$driver ?: self::createDriver();
     }
 
     /**

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -34,7 +34,7 @@ final class Loop
      */
     public static function execute(callable $callback, LoopDriver $driver = null)
     {
-        $driver = $driver ?: $this->createDriver();
+        $driver = $driver ?: self::createDriver();
         $previousRegistry = self::$registry;
 
         $previousDriver = self::$driver;

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -74,14 +74,14 @@ final class Loop
     private static function createDriver()
     {
         if (self::$factory === null) {
-            throw new \LogicException("Can't create an event loop driver without a factory.");
+            throw new \LogicException("No loop driver factory set; Either pass a driver to Loop::execute or set a factory.");
         }
 
         $driver = self::$factory->create();
 
         if (!$driver instanceof LoopDriver) {
             $type = is_object($driver) ? "an instance of " . get_class($driver) : gettype($driver);
-            throw new \LogicException("Factory returned {$type}, but must return an instance of LoopDriver.");
+            throw new \LogicException("Loop driver factory returned {$type}, but must return an instance of LoopDriver.");
         }
 
         return $driver;

--- a/src/LoopDriverFactory.php
+++ b/src/LoopDriverFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Interop\Async\EventLoop;
+namespace Interop\Async;
 
 interface LoopDriverFactory
 {

--- a/src/LoopDriverFactory.php
+++ b/src/LoopDriverFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Interop\Async\EventLoop;
+
+interface LoopDriverFactory
+{
+	/**
+	 * Create a new event loop driver instance.
+	 *
+	 * @return LoopDriver
+	 */
+	public function create();
+}


### PR DESCRIPTION
The LoopDriverFactory SHOULD be used by driver implementations to set a default event loop driver.

This can be achieved by having a Composer autoloader like that:

``` json
{
    "autoload": {
        "files": ["src/bootstrap.php"]
    }
}
```

Where `src/bootstrap.php` contains the following code:

``` php
use Interop\Async\EventLoop\LoopDriverFactory;

class MyDriverFactory implements LoopDriverFactory
{
    public function create()
    {
        return new MyDriver();
    }
}

Loop::setFactory(new MyDriverFactory());
```

This ensures the user doesn't have to care about setting the actual driver. A user just has to require the specific event loop driver package he / she wants to use.
