### PR TITLE
Add loop bound state registry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,10 @@
         "psr-4": {
             "Interop\\Async\\": "src"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Interop\\Async\\": "test"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
     "require": {
         "php": ">=5.5.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4|^5"
+    },
     "autoload": {
         "psr-4": {
             "Interop\\Async\\": "src"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>./test</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -4,15 +4,12 @@ namespace Interop\Async;
 
 final class Loop
 {
+    use Registry;
+
     /**
      * @var LoopDriver
      */
     private static $driver = null;
-
-    /**
-     * @var array
-     */
-    private static $registry = [];
 
     /**
      * Execute a callback within the scope of an event loop driver.
@@ -62,49 +59,6 @@ final class Loop
     public static function stop()
     {
         self::get()->stop();
-    }
-
-    /**
-     * Stores information in the loop bound registry. This can be used to store
-     * loop bound information. Stored information is package private.
-     * Packages MUST NOT retrieve the stored state of other packages.
-     *
-     * Therefore packages SHOULD use the following prefix to keys:
-     * `vendor.package.`
-     *
-     * @param string $key namespaced storage key
-     * @param mixed $value the value to be stored
-     *
-     * @return void
-     */
-    public static function storeState($key, $value)
-    {
-        if (self::$driver === null) {
-            throw new \RuntimeException('Not within the scope of an event loop driver');
-        }
-
-        self::$registry[$key] = $value;
-    }
-
-    /**
-     * Fetches information stored bound to the loop. Stored information is
-     * package private. Packages MUST NOT retrieve the stored state of
-     * other packages.
-     *
-     * Therefore packages SHOULD use the following prefix to keys:
-     * `vendor.package.`
-     *
-     * @param string $key namespaced storage key
-     *
-     * @return mixed previously stored value or null if it doesn't exist
-     */
-    public static function fetchState($key)
-    {
-        if (self::$driver === null) {
-            throw new \RuntimeException('Not within the scope of an event loop driver');
-        }
-
-        return isset(self::$registry[$key]) ? self::$registry[$key] : null;
     }
 
     /**

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -33,7 +33,7 @@ final class Loop
             self::$driver->run();
         } finally {
             self::$driver = $previousDriver;
-            self::$registry = $registry;
+            self::$registry = $previousRegistry;
         }
     }
 

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Interop\Async\EventLoop;
+namespace Interop\Async;
 
 trait Registry {
     /**

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -2,7 +2,8 @@
 
 namespace Interop\Async;
 
-trait Registry {
+trait Registry
+{
     /**
      * @var array
      */

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Interop\Async\EventLoop;
+
+trait Registry {
+    /**
+     * @var array
+     */
+    private static $registry = null;
+
+    /**
+     * Stores information in the loop bound registry. This can be used to store
+     * loop bound information. Stored information is package private.
+     * Packages MUST NOT retrieve the stored state of other packages.
+     *
+     * Therefore packages SHOULD use the following prefix to keys:
+     * `vendor.package.`
+     *
+     * @param string $key namespaced storage key
+     * @param mixed $value the value to be stored
+     *
+     * @return void
+     */
+    public static function storeState($key, $value)
+    {
+        if (self::$registry === null) {
+            throw new \RuntimeException('Not within the scope of an event loop driver');
+        }
+
+        if ($value === null) {
+            unset(self::$registry[$key]);
+        } else {
+            self::$registry[$key] = $value;
+        }
+    }
+
+    /**
+     * Fetches information stored bound to the loop. Stored information is
+     * package private. Packages MUST NOT retrieve the stored state of
+     * other packages.
+     *
+     * Therefore packages SHOULD use the following prefix to keys:
+     * `vendor.package.`
+     *
+     * @param string $key namespaced storage key
+     *
+     * @return mixed previously stored value or null if it doesn't exist
+     */
+    public static function fetchState($key)
+    {
+        if (self::$registry === null) {
+            throw new \RuntimeException('Not within the scope of an event loop driver');
+        }
+
+        return isset(self::$registry[$key]) ? self::$registry[$key] : null;
+    }
+}

--- a/src/UnsupportedFeatureException.php
+++ b/src/UnsupportedFeatureException.php
@@ -6,4 +6,7 @@ use Interop\Async;
  * Must be thrown if an optional feature is not supported by the current driver
  * or system.
  */
-class UnsupportedFeatureException extends \RuntimeException { }
+class UnsupportedFeatureException extends \RuntimeException
+{
+
+}

--- a/test/RegistryTest.php
+++ b/test/RegistryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Interop\Async\EventLoop;
+
+class RegistryTest extends \PHPUnit_Framework_TestCase {
+    use Registry;
+
+    protected function setUp() {
+        self::$registry = null;
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     */
+    public function fetchfailsOutsideOfLoop() {
+        self::fetchState("foobar");
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     */
+    public function storefailsOutsideOfLoop() {
+        self::fetchState("store");
+    }
+
+    /** @test */
+    public function defaultsToNull() {
+        // emulate we're in an event loop…
+        self::$registry = [];
+        $this->assertNull(self::fetchState("foobar"));
+    }
+
+    /**
+     * @test
+     * @dataProvider provideValues
+     */
+    public function fetchesStoredValue($value) {
+        // emulate we're in an event loop…
+        self::$registry = [];
+
+        $this->assertNull(self::fetchState("foobar"));
+        self::storeState("foobar", $value);
+
+        $this->assertSame($value, self::fetchState("foobar"));
+    }
+
+    public function provideValues() {
+        return [
+            ["string"],
+            [42],
+            [1.001],
+            [true],
+            [false],
+            [null],
+            [new \StdClass],
+        ];
+    }
+}

--- a/test/RegistryTest.php
+++ b/test/RegistryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Interop\Async\EventLoop;
+namespace Interop\Async;
 
 class RegistryTest extends \PHPUnit_Framework_TestCase {
     use Registry;

--- a/test/RegistryTest.php
+++ b/test/RegistryTest.php
@@ -2,10 +2,12 @@
 
 namespace Interop\Async;
 
-class RegistryTest extends \PHPUnit_Framework_TestCase {
+class RegistryTest extends \PHPUnit_Framework_TestCase
+{
     use Registry;
 
-    protected function setUp() {
+    protected function setUp()
+    {
         self::$registry = null;
     }
 
@@ -13,7 +15,8 @@ class RegistryTest extends \PHPUnit_Framework_TestCase {
      * @test
      * @expectedException \RuntimeException
      */
-    public function fetchfailsOutsideOfLoop() {
+    public function fetchfailsOutsideOfLoop()
+    {
         self::fetchState("foobar");
     }
 
@@ -21,12 +24,14 @@ class RegistryTest extends \PHPUnit_Framework_TestCase {
      * @test
      * @expectedException \RuntimeException
      */
-    public function storefailsOutsideOfLoop() {
+    public function storefailsOutsideOfLoop()
+    {
         self::fetchState("store");
     }
 
     /** @test */
-    public function defaultsToNull() {
+    public function defaultsToNull()
+    {
         // emulate we're in an event loop…
         self::$registry = [];
         $this->assertNull(self::fetchState("foobar"));
@@ -36,7 +41,8 @@ class RegistryTest extends \PHPUnit_Framework_TestCase {
      * @test
      * @dataProvider provideValues
      */
-    public function fetchesStoredValue($value) {
+    public function fetchesStoredValue($value)
+    {
         // emulate we're in an event loop…
         self::$registry = [];
 
@@ -46,7 +52,8 @@ class RegistryTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($value, self::fetchState("foobar"));
     }
 
-    public function provideValues() {
+    public function provideValues()
+    {
         return [
             ["string"],
             [42],


### PR DESCRIPTION
The registry allows to store information bound to a specific loop. This can be useful to store state of globals like a DNS resolver.

**Rationale for a global DNS resolver**

Nobody wants to inject a resolver into everything that does some sort of I/O. Using IP addresses everywhere instead of hostnames also doesn't make sense.

Therefore there should be a global default DNS resolver. But this resolver needs a read watcher for the response. If the loop gets swapped and a DNS request is made, the resolver would never get the read event, since the stream is only watched in the old loop. The resolver also doesn't get any info about the loop swap, so it can't use a new watcher.

With a loop bound registry, it can just store the connection in the loop and will use a new connection when the loop is swapped, because the state doesn't exist any longer. Once the loop is put back, it can use the old connection again.

This API should only be used by real global objects. Most packages won't need to use this API, but it's required for the mentioned use cases.
