### PR TITLE
Add watcher data parameter

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -60,12 +60,13 @@ final class Loop
      * Defer the execution of a callback.
      *
      * @param callable $callback The callback to defer.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function defer(callable $callback)
+    public static function defer(callable $callback, $data = null)
     {
-        return self::get()->defer($callback);
+        return self::get()->defer($callback, $data);
     }
 
     /**
@@ -73,12 +74,13 @@ final class Loop
      *
      * @param callable $callback The callback to delay.
      * @param int $time The amount of time, in milliseconds, to delay the execution for.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function delay(callable $callback, $time)
+    public static function delay(callable $callback, $time, $data = null)
     {
-        return self::get()->delay($callback, $time);
+        return self::get()->delay($callback, $time, $data);
     }
 
     /**
@@ -86,12 +88,13 @@ final class Loop
      *
      * @param callable $callback The callback to repeat.
      * @param int $interval The time interval, in milliseconds, to wait between executions.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function repeat(callable $callback, $interval)
+    public static function repeat(callable $callback, $interval, $data = null)
     {
-        return self::get()->repeat($callback, $interval);
+        return self::get()->repeat($callback, $interval, $data);
     }
 
     /**
@@ -99,12 +102,13 @@ final class Loop
      *
      * @param resource $stream The stream to monitor.
      * @param callable $callback The callback to execute.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function onReadable($stream, callable $callback)
+    public static function onReadable($stream, callable $callback, $data = null)
     {
-        return self::get()->onReadable($stream, $callback);
+        return self::get()->onReadable($stream, $callback, $data);
     }
 
     /**
@@ -112,12 +116,13 @@ final class Loop
      *
      * @param resource $stream The stream to monitor.
      * @param callable $callback The callback to execute.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function onWritable($stream, callable $callback)
+    public static function onWritable($stream, callable $callback, $data = null)
     {
-        return self::get()->onWritable($stream, $callback);
+        return self::get()->onWritable($stream, $callback, $data);
     }
 
     /**
@@ -125,12 +130,13 @@ final class Loop
      *
      * @param int $signo The signal number to monitor.
      * @param callable $callback The callback to execute.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public static function onSignal($signo, callable $callback)
+    public static function onSignal($signo, callable $callback, $data = null)
     {
-        return self::get()->onSignal($signo, $callback);
+        return self::get()->onSignal($signo, $callback, $data);
     }
 
     /**

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -59,7 +59,7 @@ final class Loop
     /**
      * Defer the execution of a callback.
      *
-     * @param callable $callback The callback to defer.
+     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to defer.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
@@ -72,7 +72,7 @@ final class Loop
     /**
      * Delay the execution of a callback. The time delay is approximate and accuracy is not guaranteed.
      *
-     * @param callable $callback The callback to delay.
+     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to delay.
      * @param int $time The amount of time, in milliseconds, to delay the execution for.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
@@ -86,7 +86,7 @@ final class Loop
     /**
      * Repeatedly execute a callback. The interval between executions is approximate and accuracy is not guaranteed.
      *
-     * @param callable $callback The callback to repeat.
+     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to repeat.
      * @param int $interval The time interval, in milliseconds, to wait between executions.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
@@ -101,7 +101,7 @@ final class Loop
      * Execute a callback when a stream resource becomes readable.
      *
      * @param resource $stream The stream to monitor.
-     * @param callable $callback The callback to execute.
+     * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
@@ -115,7 +115,7 @@ final class Loop
      * Execute a callback when a stream resource becomes writable.
      *
      * @param resource $stream The stream to monitor.
-     * @param callable $callback The callback to execute.
+     * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
@@ -129,7 +129,7 @@ final class Loop
      * Execute a callback when a signal is received.
      *
      * @param int $signo The signal number to monitor.
-     * @param callable $callback The callback to execute.
+     * @param callable(int $signo, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
@@ -142,7 +142,7 @@ final class Loop
     /**
      * Execute a callback when an error occurs.
      *
-     * @param callable $callback The callback to execute.
+     * @param callable(\Throwable|\Exception $exception) $callback The callback to execute.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -62,7 +62,7 @@ final class Loop
      * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to defer.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public static function defer(callable $callback, $data = null)
     {
@@ -76,7 +76,7 @@ final class Loop
      * @param int $time The amount of time, in milliseconds, to delay the execution for.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public static function delay(callable $callback, $time, $data = null)
     {
@@ -90,7 +90,7 @@ final class Loop
      * @param int $interval The time interval, in milliseconds, to wait between executions.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public static function repeat(callable $callback, $interval, $data = null)
     {
@@ -104,7 +104,7 @@ final class Loop
      * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public static function onReadable($stream, callable $callback, $data = null)
     {
@@ -118,7 +118,7 @@ final class Loop
      * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public static function onWritable($stream, callable $callback, $data = null)
     {
@@ -132,7 +132,7 @@ final class Loop
      * @param callable(int $signo, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public static function onSignal($signo, callable $callback, $data = null)
     {
@@ -144,7 +144,7 @@ final class Loop
      *
      * @param callable(\Throwable|\Exception $exception) $callback The callback to execute.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public static function onError(callable $callback)
     {
@@ -152,68 +152,69 @@ final class Loop
     }
 
     /**
-     * Enable an event.
+     * Enable a watcher.
      *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public static function enable($eventIdentifier)
+    public static function enable($watcherIdentifier)
     {
-        self::get()->enable($eventIdentifier);
+        self::get()->enable($watcherIdentifier);
     }
 
     /**
-     * Disable an event.
+     * Disable a watcher.
      *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public static function disable($eventIdentifier)
+    public static function disable($watcherIdentifier)
     {
-        self::get()->disable($eventIdentifier);
+        self::get()->disable($watcherIdentifier);
     }
 
     /**
-     * Cancel an event.
+     * Cancel a watcher.
      *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public static function cancel($eventIdentifier)
+    public static function cancel($watcherIdentifier)
     {
-        self::get()->cancel($eventIdentifier);
+        self::get()->cancel($watcherIdentifier);
     }
 
     /**
-     * Reference an event.
+     * Reference a watcher.
      *
-     * This will keep the event loop alive whilst the event is still being monitored. Events have this state by default.
+     * This will keep the event loop alive whilst the event is still being monitored. Watchers have this state by
+     * default.
      *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public static function reference($eventIdentifier)
+    public static function reference($watcherIdentifier)
     {
-        self::get()->reference($eventIdentifier);
+        self::get()->reference($watcherIdentifier);
     }
 
     /**
-     * Unreference an event.
+     * Unreference a watcher.
      *
-     * The event loop should exit the run method when only unreferenced events are still being monitored. Events are all
-     * referenced by default.
+     * The event loop should exit the run method when only unreferenced watchers are still being monitored. Events are
+     * all referenced by default.
      *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public static function unreference($eventIdentifier)
+    public static function unreference($watcherIdentifier)
     {
-        self::get()->unreference($eventIdentifier);
+        self::get()->unreference($watcherIdentifier);
     }
 
     /**

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -59,7 +59,7 @@ final class Loop
     /**
      * Defer the execution of a callback.
      *
-     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to defer.
+     * @param callable(string $watcherId, mixed $data) $callback The callback to defer.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
@@ -72,7 +72,7 @@ final class Loop
     /**
      * Delay the execution of a callback. The time delay is approximate and accuracy is not guaranteed.
      *
-     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to delay.
+     * @param callable(string $watcherId, mixed $data) $callback The callback to delay.
      * @param int $time The amount of time, in milliseconds, to delay the execution for.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
@@ -86,7 +86,7 @@ final class Loop
     /**
      * Repeatedly execute a callback. The interval between executions is approximate and accuracy is not guaranteed.
      *
-     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to repeat.
+     * @param callable(string $watcherId, mixed $data) $callback The callback to repeat.
      * @param int $interval The time interval, in milliseconds, to wait between executions.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
@@ -101,7 +101,7 @@ final class Loop
      * Execute a callback when a stream resource becomes readable.
      *
      * @param resource $stream The stream to monitor.
-     * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
+     * @param callable(string $watcherId, resource $stream, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
@@ -115,7 +115,7 @@ final class Loop
      * Execute a callback when a stream resource becomes writable.
      *
      * @param resource $stream The stream to monitor.
-     * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
+     * @param callable(string $watcherId, resource $stream, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
@@ -129,7 +129,7 @@ final class Loop
      * Execute a callback when a signal is received.
      *
      * @param int $signo The signal number to monitor.
-     * @param callable(int $signo, mixed $data, string $watcherIdentifier) $callback The callback to execute.
+     * @param callable(string $watcherId, int $signo, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
@@ -154,37 +154,37 @@ final class Loop
     /**
      * Enable a watcher.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public static function enable($watcherIdentifier)
+    public static function enable($watcherId)
     {
-        self::get()->enable($watcherIdentifier);
+        self::get()->enable($watcherId);
     }
 
     /**
      * Disable a watcher.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public static function disable($watcherIdentifier)
+    public static function disable($watcherId)
     {
-        self::get()->disable($watcherIdentifier);
+        self::get()->disable($watcherId);
     }
 
     /**
      * Cancel a watcher.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public static function cancel($watcherIdentifier)
+    public static function cancel($watcherId)
     {
-        self::get()->cancel($watcherIdentifier);
+        self::get()->cancel($watcherId);
     }
 
     /**
@@ -193,13 +193,13 @@ final class Loop
      * This will keep the event loop alive whilst the event is still being monitored. Watchers have this state by
      * default.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public static function reference($watcherIdentifier)
+    public static function reference($watcherId)
     {
-        self::get()->reference($watcherIdentifier);
+        self::get()->reference($watcherId);
     }
 
     /**
@@ -208,13 +208,13 @@ final class Loop
      * The event loop should exit the run method when only unreferenced watchers are still being monitored. Events are
      * all referenced by default.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public static function unreference($watcherIdentifier)
+    public static function unreference($watcherId)
     {
-        self::get()->unreference($watcherIdentifier);
+        self::get()->unreference($watcherId);
     }
 
     /**

--- a/src/LoopDriver.php
+++ b/src/LoopDriver.php
@@ -23,7 +23,7 @@ interface LoopDriver
     /**
      * Defer the execution of a callback.
      *
-     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to defer.
+     * @param callable(string $watcherId, mixed $data) $callback The callback to defer.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
@@ -33,7 +33,7 @@ interface LoopDriver
     /**
      * Delay the execution of a callback. The time delay is approximate and accuracy is not guaranteed.
      *
-     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to delay.
+     * @param callable(string $watcherId, mixed $data) $callback The callback to delay.
      * @param int $delay The amount of time, in milliseconds, to delay the execution for.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
@@ -44,7 +44,7 @@ interface LoopDriver
     /**
      * Repeatedly execute a callback. The interval between executions is approximate and accuracy is not guaranteed.
      *
-     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to repeat.
+     * @param callable(string $watcherId, mixed $data) $callback The callback to repeat.
      * @param int $interval The time interval, in milliseconds, to wait between executions.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
@@ -56,7 +56,7 @@ interface LoopDriver
      * Execute a callback when a stream resource becomes readable.
      *
      * @param resource $stream The stream to monitor.
-     * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
+     * @param callable(string $watcherId, resource $stream, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
@@ -67,7 +67,7 @@ interface LoopDriver
      * Execute a callback when a stream resource becomes writable.
      *
      * @param resource $stream The stream to monitor.
-     * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
+     * @param callable(string $watcherId, resource $stream, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
@@ -78,7 +78,7 @@ interface LoopDriver
      * Execute a callback when a signal is received.
      *
      * @param int $signo The signal number to monitor.
-     * @param callable(int $signo, mixed $data, string $watcherIdentifier) $callback The callback to execute.
+     * @param callable(string $watcherId, int $signo, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
@@ -97,40 +97,40 @@ interface LoopDriver
     /**
      * Enable a watcher.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public function enable($watcherIdentifier);
+    public function enable($watcherId);
 
     /**
      * Disable a watcher.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public function disable($watcherIdentifier);
+    public function disable($watcherId);
 
     /**
      * Cancel a watcher.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public function cancel($watcherIdentifier);
+    public function cancel($watcherId);
 
     /**
      * Reference a watcher.
      *
      * This will keep the event loop alive whilst the event is still being monitored. Events have this state by default.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public function reference($watcherIdentifier);
+    public function reference($watcherId);
 
     /**
      * Unreference a watcher.
@@ -138,11 +138,11 @@ interface LoopDriver
      * The event loop should exit the run method when only unreferenced events are still being monitored. Events are all
      * referenced by default.
      *
-     * @param string $watcherIdentifier The watcher identifier.
+     * @param string $watcherId The watcher identifier.
      *
      * @return void
      */
-    public function unreference($watcherIdentifier);
+    public function unreference($watcherId);
 
     /**
      * Check whether an optional features is supported by this implementation

--- a/src/LoopDriver.php
+++ b/src/LoopDriver.php
@@ -24,60 +24,66 @@ interface LoopDriver
      * Defer the execution of a callback.
      *
      * @param callable $callback The callback to defer.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function defer(callable $callback);
+    public function defer(callable $callback, $data = null);
 
     /**
      * Delay the execution of a callback. The time delay is approximate and accuracy is not guaranteed.
      *
      * @param callable $callback The callback to delay.
      * @param int $delay The amount of time, in milliseconds, to delay the execution for.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function delay(callable $callback, $delay);
+    public function delay(callable $callback, $delay, $data = null);
 
     /**
      * Repeatedly execute a callback. The interval between executions is approximate and accuracy is not guaranteed.
      *
      * @param callable $callback The callback to repeat.
      * @param int $interval The time interval, in milliseconds, to wait between executions.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function repeat(callable $callback, $interval);
+    public function repeat(callable $callback, $interval, $data = null);
 
     /**
      * Execute a callback when a stream resource becomes readable.
      *
      * @param resource $stream The stream to monitor.
      * @param callable $callback The callback to execute.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function onReadable($stream, callable $callback);
+    public function onReadable($stream, callable $callback, $data = null);
 
     /**
      * Execute a callback when a stream resource becomes writable.
      *
      * @param resource $stream The stream to monitor.
      * @param callable $callback The callback to execute.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function onWritable($stream, callable $callback);
+    public function onWritable($stream, callable $callback, $data = null);
 
     /**
      * Execute a callback when a signal is received.
      *
      * @param int $signo The signal number to monitor.
      * @param callable $callback The callback to execute.
+     * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */
-    public function onSignal($signo, callable $callback);
+    public function onSignal($signo, callable $callback, $data = null);
 
     /**
      * Execute a callback when an error occurs.

--- a/src/LoopDriver.php
+++ b/src/LoopDriver.php
@@ -23,7 +23,7 @@ interface LoopDriver
     /**
      * Defer the execution of a callback.
      *
-     * @param callable $callback The callback to defer.
+     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to defer.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
@@ -33,7 +33,7 @@ interface LoopDriver
     /**
      * Delay the execution of a callback. The time delay is approximate and accuracy is not guaranteed.
      *
-     * @param callable $callback The callback to delay.
+     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to delay.
      * @param int $delay The amount of time, in milliseconds, to delay the execution for.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
@@ -44,7 +44,7 @@ interface LoopDriver
     /**
      * Repeatedly execute a callback. The interval between executions is approximate and accuracy is not guaranteed.
      *
-     * @param callable $callback The callback to repeat.
+     * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to repeat.
      * @param int $interval The time interval, in milliseconds, to wait between executions.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
@@ -56,7 +56,7 @@ interface LoopDriver
      * Execute a callback when a stream resource becomes readable.
      *
      * @param resource $stream The stream to monitor.
-     * @param callable $callback The callback to execute.
+     * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
@@ -67,7 +67,7 @@ interface LoopDriver
      * Execute a callback when a stream resource becomes writable.
      *
      * @param resource $stream The stream to monitor.
-     * @param callable $callback The callback to execute.
+     * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
@@ -78,7 +78,7 @@ interface LoopDriver
      * Execute a callback when a signal is received.
      *
      * @param int $signo The signal number to monitor.
-     * @param callable $callback The callback to execute.
+     * @param callable(int $signo, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
@@ -88,7 +88,7 @@ interface LoopDriver
     /**
      * Execute a callback when an error occurs.
      *
-     * @param callable $callback The callback to execute.
+     * @param callable(\Throwable|\Exception $exception) $callback The callback to execute.
      *
      * @return string An identifier that can be used to cancel, enable or disable the event.
      */

--- a/src/LoopDriver.php
+++ b/src/LoopDriver.php
@@ -26,7 +26,7 @@ interface LoopDriver
      * @param callable(mixed $data, string $watcherIdentifier) $callback The callback to defer.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public function defer(callable $callback, $data = null);
 
@@ -37,7 +37,7 @@ interface LoopDriver
      * @param int $delay The amount of time, in milliseconds, to delay the execution for.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public function delay(callable $callback, $delay, $data = null);
 
@@ -48,7 +48,7 @@ interface LoopDriver
      * @param int $interval The time interval, in milliseconds, to wait between executions.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public function repeat(callable $callback, $interval, $data = null);
 
@@ -59,7 +59,7 @@ interface LoopDriver
      * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public function onReadable($stream, callable $callback, $data = null);
 
@@ -70,7 +70,7 @@ interface LoopDriver
      * @param callable(resource $stream, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public function onWritable($stream, callable $callback, $data = null);
 
@@ -81,7 +81,7 @@ interface LoopDriver
      * @param callable(int $signo, mixed $data, string $watcherIdentifier) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public function onSignal($signo, callable $callback, $data = null);
 
@@ -90,59 +90,59 @@ interface LoopDriver
      *
      * @param callable(\Throwable|\Exception $exception) $callback The callback to execute.
      *
-     * @return string An identifier that can be used to cancel, enable or disable the event.
+     * @return string An identifier that can be used to cancel, enable or disable the watcher.
      */
     public function onError(callable $callback);
 
     /**
-     * Enable an event.
+     * Enable a watcher.
      *
-     * @param string $eventIdentifier The event identifier.
-     *
-     * @return void
-     */
-    public function enable($eventIdentifier);
-
-    /**
-     * Disable an event.
-     *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public function disable($eventIdentifier);
+    public function enable($watcherIdentifier);
 
     /**
-     * Cancel an event.
+     * Disable a watcher.
      *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public function cancel($eventIdentifier);
+    public function disable($watcherIdentifier);
 
     /**
-     * Reference an event.
+     * Cancel a watcher.
+     *
+     * @param string $watcherIdentifier The watcher identifier.
+     *
+     * @return void
+     */
+    public function cancel($watcherIdentifier);
+
+    /**
+     * Reference a watcher.
      *
      * This will keep the event loop alive whilst the event is still being monitored. Events have this state by default.
      *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public function reference($eventIdentifier);
+    public function reference($watcherIdentifier);
 
     /**
-     * Unreference an event.
+     * Unreference a watcher.
      *
      * The event loop should exit the run method when only unreferenced events are still being monitored. Events are all
      * referenced by default.
      *
-     * @param string $eventIdentifier The event identifier.
+     * @param string $watcherIdentifier The watcher identifier.
      *
      * @return void
      */
-    public function unreference($eventIdentifier);
+    public function unreference($watcherIdentifier);
 
     /**
      * Check whether an optional features is supported by this implementation


### PR DESCRIPTION
This PR addresses the issued raised in #12 by adding a data parameter to methods creating watchers. The arbitrary data given to this parameter is passed to the `$data` parameter on watcher callbacks.
#22 is also addressed by defining watcher callback signatures in the docblocks of methods creating watchers.
