### PR TITLE
Change package description to include 'for interoperability'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "async-interop/event-loop",
-    "description": "An event loop interface",
+    "description": "An event loop interface for interoperability.",
     "keywords": ["event", "loop", "async", "interop"],
     "license": "MIT",
     "require": {


### PR DESCRIPTION
Extracted from #36. I think we should state our goal in the description.
