### PR TITLE
Changed onError() to setErrorHandler()

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -145,18 +145,6 @@ final class Loop
     }
 
     /**
-     * Execute a callback when an error occurs.
-     *
-     * @param callable(\Throwable|\Exception $exception) $callback The callback to execute.
-     *
-     * @return string An identifier that can be used to cancel, enable or disable the watcher.
-     */
-    public static function onError(callable $callback)
-    {
-        return self::get()->onError($callback);
-    }
-
-    /**
      * Enable a watcher.
      *
      * @param string $watcherId The watcher identifier.
@@ -220,6 +208,20 @@ final class Loop
     public static function unreference($watcherId)
     {
         self::get()->unreference($watcherId);
+    }
+
+    /**
+     * Set a callback to be executed when an error occurs.
+     *
+     * Subsequent calls to this method will overwrite the previous handler.
+     *
+     * @param callable(\Throwable|\Exception $error)|null $callback The callback to execute; null will clear the current handler.
+     *
+     * @return void
+     */
+    public static function setErrorHandler(callable $callback = null)
+    {
+        self::get()->setErrorHandler($callback);
     }
 
     /**

--- a/src/LoopDriver.php
+++ b/src/LoopDriver.php
@@ -86,15 +86,6 @@ interface LoopDriver
     public function onSignal($signo, callable $callback, $data = null);
 
     /**
-     * Execute a callback when an error occurs.
-     *
-     * @param callable(\Throwable|\Exception $exception) $callback The callback to execute.
-     *
-     * @return string An identifier that can be used to cancel, enable or disable the watcher.
-     */
-    public function onError(callable $callback);
-
-    /**
      * Enable a watcher.
      *
      * @param string $watcherId The watcher identifier.
@@ -143,6 +134,17 @@ interface LoopDriver
      * @return void
      */
     public function unreference($watcherId);
+
+    /**
+     * Set a callback to be executed when an error occurs.
+     *
+     * Subsequent calls to this method will overwrite the previous handler.
+     *
+     * @param callable(\Throwable|\Exception $error)|null $callback The callback to execute; null will clear the current handler.
+     *
+     * @return void
+     */
+    public function setErrorHandler(callable $callback = null);
 
     /**
      * Check whether an optional features is supported by this implementation


### PR DESCRIPTION
As per the discussion here: https://github.com/async-interop/event-loop/issues/33

There was some talk in the discussion about whether you would be able to enable/disable/reference/unreference this and treat it like other events.

This PR doesn't do that, because I think it raises a few complications (are error handlers automatically unreferenced?) that might lead to bugs and ultimately doesn't add any functionality.

If anyone disagrees with my assessment, feel free to thumbs down here and we'll move the discussion back to the issue.
