### PR TITLE
Add getLoopHandle() for accessing the underlying loop

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -223,16 +223,6 @@ final class Loop
     }
 
     /**
-     * Get the underlying loop handle.
-     *
-     * @return null|object|resource The loop handle the event loop operates on. Null if there is none.
-     */
-    public static function getLoopHandle()
-    {
-        return self::get()->getLoopHandle();
-    }
-
-    /**
      * Disable construction as this is a static class.
      */
     private function __construct() {}

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -227,7 +227,8 @@ final class Loop
      *
      * @return null|object|resource The loop handle the event loop operates on. Null if there is none.
      */
-    public static function getLoopHandle() {
+    public static function getLoopHandle()
+    {
         return self::get()->getLoopHandle();
     }
 

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -223,6 +223,15 @@ final class Loop
     }
 
     /**
+     * Get the underlying loop handle.
+     *
+     * @return null|object|resource The loop handle the event loop operates on. Null if there is none.
+     */
+    public static function getLoopHandle() {
+        return self::get()->getLoopHandle();
+    }
+
+    /**
      * Disable construction as this is a static class.
      */
     private function __construct() {}

--- a/src/LoopDriver.php
+++ b/src/LoopDriver.php
@@ -157,7 +157,9 @@ interface LoopDriver
      *
      * Example: the uv_loop resource for libuv or the EvLoop object for libev or null for a native driver
      *
+     * Note: This function is *not* exposed in the Loop class; users shall access it directly on the respective loop instance.
+     *
      * @return null|object|resource The loop handle the event loop operates on. Null if there is none.
      */
-    public static function getLoopHandle();
+    public static function getHandle();
 }

--- a/src/LoopDriver.php
+++ b/src/LoopDriver.php
@@ -151,4 +151,13 @@ interface LoopDriver
      * @return bool
      */
     public function supports($feature);
+
+    /**
+     * Get the underlying loop handle.
+     *
+     * Example: the uv_loop resource for libuv or the EvLoop object for libev or null for a native driver
+     *
+     * @return null|object|resource The loop handle the event loop operates on. Null if there is none.
+     */
+    public static function getLoopHandle();
 }


### PR DESCRIPTION
These resources or objects may then be attributed to a specific extension via instanceof or get_resource_type() in implementations.

This should fix the remaining issue with #16 for e.g. filesystem drivers.

This will then look like (filesystem example):

``` php
$handle = Loop::getLoopHandle();
if (is_resource($handle) && get_resource_type($handle) == "uv_loop") {
    $fs = new UvFilesystem($handle);
} else {
    $fs = new NativeFilesystem($handle);
}
```

Which should solve all our needs, I think.
