### PR TITLE
Drop Loop::supports

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -275,19 +275,6 @@ final class Loop
     }
 
     /**
-     * Check whether an optional feature is supported by the current event loop
-     * driver.
-     *
-     * @param int $feature Loop::FEATURE_* constant
-     *
-     * @return bool
-     */
-    public static function supports($feature)
-    {
-        return self::get()->supports($feature);
-    }
-
-    /**
      * Disable construction as this is a static class.
      */
     private function __construct()

--- a/src/LoopDriver.php
+++ b/src/LoopDriver.php
@@ -147,20 +147,6 @@ interface LoopDriver
     public function setErrorHandler(callable $callback = null);
 
     /**
-     * Check whether an optional features is supported by this implementation
-     * and system.
-     *
-     * Example: If the implementation can handle signals using PCNTL, but the
-     * PCNTL extension is not available, the feature MUST NOT be marked as
-     * supported.
-     *
-     * @param int $feature FEATURE constant
-     *
-     * @return bool
-     */
-    public function supports($feature);
-
-    /**
      * Get the underlying loop handle.
      *
      * Example: the uv_loop resource for libuv or the EvLoop object for libev or null for a native driver

--- a/src/UnsupportedFeatureException.php
+++ b/src/UnsupportedFeatureException.php
@@ -3,8 +3,9 @@
 use Interop\Async;
 
 /**
- * Must be thrown if an optional feature is not supported by the current driver
- * or system.
+ * Must be thrown if a feature is not supported by the system.
+ *
+ * This might happen if PCNTL is missing and the loop driver doesn't support another way to dispatch signals.
  */
 class UnsupportedFeatureException extends \RuntimeException
 {


### PR DESCRIPTION
Redefine `UnsupportedFeatureException` to be only thrown if the system doesn't support the feature. Drivers MUST support it if PCNTL or something similar is available.

PR resolves #50.
