### PR TITLE
Fix running flag, factory reset, etc.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Interop\\Async\\": "test"
+            "Interop\\Async\\Loop": "test"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Interop\\Async\\Loop": "test"
+            "Interop\\Async\\Loop\\": "test"
         }
     }
 }

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -17,9 +17,9 @@ final class Loop
     private static $driver = null;
 
     /**
-     * @var bool
+     * @var int
      */
-    private static $running = false;
+    private static $level = 0;
 
     /**
      * Set the factory to be used to create a driver if none is passed to
@@ -30,7 +30,7 @@ final class Loop
     {
         self::$factory = $factory;
 
-        if (!self::$running) {
+        if (self::$level === 0) {
             self::$driver = self::createDriver();
             self::$registry = [];
         }
@@ -53,7 +53,7 @@ final class Loop
 
         self::$driver = $driver;
         self::$registry = [];
-        self::$running = true;
+        self::$level++;
 
         try {
             $callback();
@@ -62,7 +62,7 @@ final class Loop
         } finally {
             self::$driver = $previousDriver;
             self::$registry = $previousRegistry;
-            self::$running = false;
+            self::$level--;
         }
     }
 

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -22,15 +22,26 @@ final class Loop
     private static $level = 0;
 
     /**
-     * Set the factory to be used to create a driver if none is passed to
-     * self::execute. A default driver will be created if none is running
-     * to support synchronous waits in traditional applications.
+     * Set the factory to be used to create a default drivers.
+     *
+     * Setting a factory is only allowed as long as no loop is currently running.
+     * Passing null will reset the default driver and remove the factory.
+     *
+     * The factory will be invoked if none is passed to Loop::execute. A default driver will be created to support
+     * synchronous waits in traditional applications.
      */
     public static function setFactory(LoopDriverFactory $factory = null)
     {
+        if (self::$level > 0) {
+            throw new \RuntimeException("Setting a new factory while running isn't allowed!");
+        }
+
         self::$factory = $factory;
 
-        if (self::$level === 0) {
+        if ($factory === null) {
+            self::$driver = null;
+            self::$registry = null;
+        } else {
             self::$driver = self::createDriver();
             self::$registry = [];
         }

--- a/test/LoopTest.php
+++ b/test/LoopTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Interop\Async\Loop;
+
+use Interop\Async\Loop;
+use Interop\Async\LoopDriver;
+use Interop\Async\LoopDriverFactory;
+
+class LoopTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp() {
+        Loop::setFactory(null);
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage new factory while running isn't allowed
+     */
+    public function setFactoryFailsIfRunning() {
+        $driver = $this->getMockBuilder(LoopDriver::class)->getMock();
+
+        $factory = $this->getMockBuilder(LoopDriverFactory::class)->getMock();
+        $factory->method("create")->willReturn($driver);
+
+        Loop::setFactory($factory);
+
+        Loop::execute(function () use ($factory) {
+            Loop::setFactory($factory);
+        });
+    }
+
+    /** @test */
+    public function executeStackReturnsScopedDriver() {
+        $driver1 = $this->getMockBuilder(LoopDriver::class)->getMock();
+        $driver2 = $this->getMockBuilder(LoopDriver::class)->getMock();
+
+        Loop::execute(function () use ($driver1, $driver2) {
+            $this->assertSame($driver1, Loop::get());
+
+            Loop::execute(function () use ($driver2) {
+                $this->assertSame($driver2, Loop::get());
+            }, $driver2);
+
+            $this->assertSame($driver1, Loop::get());
+        }, $driver1);
+    }
+}

--- a/test/RegistryTest.php
+++ b/test/RegistryTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Interop\Async;
+namespace Interop\Async\Loop;
+
+use Interop\Async\Registry;
 
 class RegistryTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
- Fixes resetting the factory by passing `null`.
- Fixes the `$running` flag, which didn't work with nesting so far, thanks @AndrewCarterUK.
- Forbids calling `Loop::setFactory` while in a running loop, as I don't think that's a good idea, because we have that default driver thing to support `wait`.
