### PR TITLE
Throw on invalid watcher identifier

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -4,6 +4,8 @@ namespace Interop\Async;
 
 use Interop\Async\Loop\Driver;
 use Interop\Async\Loop\DriverFactory;
+use Interop\Async\Loop\InvalidWatcherException;
+use Interop\Async\Loop\UnsupportedFeatureException;
 
 final class Loop
 {
@@ -209,6 +211,8 @@ final class Loop
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
+     *
+     * @throws UnsupportedFeatureException Thrown if signal handling is not supported.
      */
     public static function onSignal($signo, callable $callback, $data = null)
     {
@@ -221,6 +225,8 @@ final class Loop
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public static function enable($watcherId)
     {
@@ -233,6 +239,8 @@ final class Loop
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public static function disable($watcherId)
     {
@@ -245,6 +253,8 @@ final class Loop
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public static function cancel($watcherId)
     {
@@ -260,6 +270,8 @@ final class Loop
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public static function reference($watcherId)
     {
@@ -275,6 +287,8 @@ final class Loop
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public static function unreference($watcherId)
     {

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -226,7 +226,7 @@ final class Loop
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public static function enable($watcherId)
     {
@@ -240,7 +240,7 @@ final class Loop
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public static function disable($watcherId)
     {
@@ -254,7 +254,7 @@ final class Loop
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public static function cancel($watcherId)
     {
@@ -271,7 +271,7 @@ final class Loop
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public static function reference($watcherId)
     {
@@ -288,7 +288,7 @@ final class Loop
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public static function unreference($watcherId)
     {

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -106,7 +106,7 @@ interface Driver
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public function enable($watcherId);
 
@@ -117,7 +117,7 @@ interface Driver
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public function disable($watcherId);
 
@@ -128,7 +128,7 @@ interface Driver
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public function cancel($watcherId);
 
@@ -142,7 +142,7 @@ interface Driver
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public function reference($watcherId);
 
@@ -156,7 +156,7 @@ interface Driver
      *
      * @return void
      *
-     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid or cancelled.
      */
     public function unreference($watcherId);
 

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -111,7 +111,7 @@ interface Driver
     public function enable($watcherId);
 
     /**
-     * Disable a watcher.
+     * Disable a watcher. Disabling a watcher MUST NOT invalidate the watcher.
      *
      * @param string $watcherId The watcher identifier.
      *

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -94,6 +94,8 @@ interface Driver
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
      *
      * @return string An identifier that can be used to cancel, enable or disable the watcher.
+     *
+     * @throws UnsupportedFeatureException Thrown if signal handling is not supported.
      */
     public function onSignal($signo, callable $callback, $data = null);
 
@@ -103,6 +105,8 @@ interface Driver
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public function enable($watcherId);
 
@@ -112,6 +116,8 @@ interface Driver
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public function disable($watcherId);
 
@@ -121,6 +127,8 @@ interface Driver
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public function cancel($watcherId);
 
@@ -133,6 +141,8 @@ interface Driver
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public function reference($watcherId);
 
@@ -145,6 +155,8 @@ interface Driver
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException Thrown if the watcher identifier is invalid.
      */
     public function unreference($watcherId);
 

--- a/src/Loop/InvalidWatcherException.php
+++ b/src/Loop/InvalidWatcherException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Interop\Async\Loop;
+
+/**
+ * Must be thrown if an operation is attempted with an invalid watcher identifier.
+ */
+class InvalidWatcherException extends \RuntimeException
+{
+
+}

--- a/src/Loop/InvalidWatcherException.php
+++ b/src/Loop/InvalidWatcherException.php
@@ -5,7 +5,7 @@ namespace Interop\Async\Loop;
 /**
  * Must be thrown if an operation is attempted with an invalid watcher identifier.
  */
-class InvalidWatcherException extends \RuntimeException
+class InvalidWatcherException extends \LogicException
 {
 
 }


### PR DESCRIPTION
Addresses #58. Adds `InvalidWatcherExeption` that should be thrown if `enable`, `disable`, `cancel`, `reference`, or `unreference` is attempted with an invalid watcher identifier.
