### PR TITLE
Put Loop::execute() $callback into Driver::defer()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Interop\\Async\\Loop\\": "test"
+            "Interop\\Async\\Loop\\Test\\": "test"
         }
     }
 }

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -72,8 +72,7 @@ final class Loop
         self::$level++;
 
         try {
-            $callback();
-
+            self::$driver->defer($callback);
             self::$driver->run();
         } finally {
             self::$driver = $previousDriver;

--- a/test/DummyDriver.php
+++ b/test/DummyDriver.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Interop\Async\Loop\Test;
+
+class DummyDriver implements \Interop\Async\Loop\Driver
+{
+    public $defers;
+    public $handler;
+    public static $id = "a";
+
+    public function run() {
+        while (list($defer, $data) = array_shift($this->defers)) {
+            try {
+                $defer(self::$id++, $data);
+            } catch (Exception $e) {
+                if ($handler = $this->handler) {
+                    $handler($e);
+                } else {
+                    throw $e;
+                }
+            }
+        }
+    }
+
+    public function defer(callable $callback, $data = null) {
+        $this->defers[] = [$callback, $data];
+    }
+
+    public function setErrorHandler(callable $callback = null) {
+        $this->handler = $callback;
+    }
+
+    public function stop() {}
+    public function delay($delay, callable $callback, $data = null) { return self::$id++; }
+    public function repeat($interval, callable $callback, $data = null) { return self::$id++; }
+    public function onReadable($stream, callable $callback, $data = null) { return self::$id++; }
+    public function onWritable($stream, callable $callback, $data = null) { return self::$id++; }
+    public function onSignal($signo, callable $callback, $data = null) { return self::$id++; }
+    public function enable($watcherId) {}
+    public function disable($watcherId) {}
+    public function cancel($watcherId) {}
+    public function reference($watcherId) {}
+    public function unreference($watcherId) {}
+    public function info() {}
+    public function getHandle() {}
+}

--- a/test/LoopTest.php
+++ b/test/LoopTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Interop\Async\Loop;
+namespace Interop\Async\Loop\Test;
 
 use Interop\Async\Loop;
 
@@ -16,9 +16,9 @@ class LoopTest extends \PHPUnit_Framework_TestCase
      * @expectedExceptionMessage new factory while running isn't allowed
      */
     public function setFactoryFailsIfRunning() {
-        $driver = $this->getMockBuilder(Driver::class)->getMock();
+        $driver = new DummyDriver;
 
-        $factory = $this->getMockBuilder(DriverFactory::class)->getMock();
+        $factory = $this->getMockBuilder(Loop\DriverFactory::class)->getMock();
         $factory->method("create")->willReturn($driver);
 
         Loop::setFactory($factory);
@@ -30,8 +30,8 @@ class LoopTest extends \PHPUnit_Framework_TestCase
 
     /** @test */
     public function executeStackReturnsScopedDriver() {
-        $driver1 = $this->getMockBuilder(Driver::class)->getMock();
-        $driver2 = $this->getMockBuilder(Driver::class)->getMock();
+        $driver1 = new DummyDriver;
+        $driver2 = new DummyDriver;
 
         Loop::execute(function () use ($driver1, $driver2) {
             $this->assertSame($driver1, Loop::get());


### PR DESCRIPTION
This also ensures that potential throwing in the callback will be handled inside a potential error handler instead of immediately falling through.

P.s.: Test changes are necessary as it now is in defer()... Thus need to execute the defers...
