### PR TITLE
Driver registry

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -7,8 +7,6 @@ use Interop\Async\Loop\DriverFactory;
 
 final class Loop
 {
-    use Loop\Registry;
-
     /**
      * @var DriverFactory
      */
@@ -45,10 +43,8 @@ final class Loop
 
         if ($factory === null) {
             self::$driver = null;
-            self::$registry = null;
         } else {
             self::$driver = self::createDriver();
-            self::$registry = [];
         }
     }
 
@@ -62,13 +58,11 @@ final class Loop
      */
     public static function execute(callable $callback, Driver $driver = null)
     {
-        $previousRegistry = self::$registry;
         $previousDriver = self::$driver;
 
         $driver = $driver ?: self::createDriver();
 
         self::$driver = $driver;
-        self::$registry = [];
         self::$level++;
 
         try {
@@ -77,7 +71,6 @@ final class Loop
             self::$driver->run();
         } finally {
             self::$driver = $previousDriver;
-            self::$registry = $previousRegistry;
             self::$level--;
         }
     }
@@ -279,6 +272,37 @@ final class Loop
     public static function unreference($watcherId)
     {
         self::get()->unreference($watcherId);
+    }
+
+    /**
+     * Stores information in the loop bound registry. This can be used to store loop bound information. Stored
+     * information is package private. Packages MUST NOT retrieve the stored state of other packages.
+     *
+     * Therefore packages SHOULD use the following prefix to keys: `vendor.package.`
+     *
+     * @param string $key namespaced storage key
+     * @param mixed $value the value to be stored
+     *
+     * @return void
+     */
+    public static function storeState($key, $value)
+    {
+        self::get()->storeState($key, $value);
+    }
+
+    /**
+     * Fetches information stored bound to the loop. Stored information is package private. Packages MUST NOT retrieve
+     * the stored state of other packages.
+     *
+     * Therefore packages SHOULD use the following prefix to keys: `vendor.package.`
+     *
+     * @param string $key namespaced storage key
+     *
+     * @return mixed previously stored value or null if it doesn't exist
+     */
+    public static function fetchState($key)
+    {
+        return self::get()->fetchState($key);
     }
 
     /**

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -149,6 +149,31 @@ interface Driver
      * @return void
      */
     public function unreference($watcherId);
+    
+    /**
+     * Stores information in the loop bound registry. This can be used to store loop bound information. Stored
+     * information is package private. Packages MUST NOT retrieve the stored state of other packages.
+     *
+     * Therefore packages SHOULD use the following prefix to keys: `vendor.package.`
+     *
+     * @param string $key namespaced storage key
+     * @param mixed $value the value to be stored
+     *
+     * @return void
+     */
+    public function storeState($key, $value);
+
+    /**
+     * Fetches information stored bound to the loop. Stored information is package private. Packages MUST NOT retrieve
+     * the stored state of other packages.
+     *
+     * Therefore packages SHOULD use the following prefix to keys: `vendor.package.`
+     *
+     * @param string $key namespaced storage key
+     *
+     * @return mixed previously stored value or null if it doesn't exist
+     */
+    public function fetchState($key);
 
     /**
      * Set a callback to be executed when an error occurs.

--- a/src/Loop/Registry.php
+++ b/src/Loop/Registry.php
@@ -3,62 +3,47 @@
 namespace Interop\Async\Loop;
 
 /**
- * State registry to be used in Interop\Async\Loop.
- *
- * THIS TRAIT SHOULD NOT BE USED BY LOOP DRIVERS. It's the responsibility of the
- * loop accessor to manage this state.
+ * State registry to be used by classes implementing the Driver interface.
  */
 trait Registry
 {
     /**
      * @var array
      */
-    private static $registry = null;
+    private $registry = [];
 
     /**
-     * Stores information in the loop bound registry. This can be used to store
-     * loop bound information. Stored information is package private.
-     * Packages MUST NOT retrieve the stored state of other packages.
+     * Stores information in the loop bound registry. This can be used to store loop bound information. Stored
+     * information is package private. Packages MUST NOT retrieve the stored state of other packages.
      *
-     * Therefore packages SHOULD use the following prefix to keys:
-     * `vendor.package.`
+     * Therefore packages SHOULD use the following prefix to keys: `vendor.package.`
      *
      * @param string $key namespaced storage key
      * @param mixed $value the value to be stored
      *
      * @return void
      */
-    public static function storeState($key, $value)
+    public function storeState($key, $value)
     {
-        if (self::$registry === null) {
-            throw new \RuntimeException('Not within the scope of an event loop driver');
-        }
-
         if ($value === null) {
-            unset(self::$registry[$key]);
+            unset($this->registry[$key]);
         } else {
-            self::$registry[$key] = $value;
+            $this->registry[$key] = $value;
         }
     }
 
     /**
-     * Fetches information stored bound to the loop. Stored information is
-     * package private. Packages MUST NOT retrieve the stored state of
-     * other packages.
+     * Fetches information stored bound to the loop. Stored information is package private. Packages MUST NOT retrieve
+     * the stored state of other packages.
      *
-     * Therefore packages SHOULD use the following prefix to keys:
-     * `vendor.package.`
+     * Therefore packages SHOULD use the following prefix to keys: `vendor.package.`
      *
      * @param string $key namespaced storage key
      *
      * @return mixed previously stored value or null if it doesn't exist
      */
-    public static function fetchState($key)
+    public function fetchState($key)
     {
-        if (self::$registry === null) {
-            throw new \RuntimeException('Not within the scope of an event loop driver');
-        }
-
-        return isset(self::$registry[$key]) ? self::$registry[$key] : null;
+        return isset($this->registry[$key]) ? $this->registry[$key] : null;
     }
 }

--- a/test/RegistryTest.php
+++ b/test/RegistryTest.php
@@ -4,37 +4,17 @@ namespace Interop\Async\Loop;
 
 class RegistryTest extends \PHPUnit_Framework_TestCase
 {
-    use Registry;
+    private $registry;
 
     protected function setUp()
     {
-        self::$registry = null;
-    }
-
-    /**
-     * @test
-     * @expectedException \RuntimeException
-     */
-    public function fetchfailsOutsideOfLoop()
-    {
-        self::fetchState("foobar");
-    }
-
-    /**
-     * @test
-     * @expectedException \RuntimeException
-     */
-    public function storefailsOutsideOfLoop()
-    {
-        self::fetchState("store");
+        $this->registry = $this->getMockForTrait(Registry::class);
     }
 
     /** @test */
     public function defaultsToNull()
     {
-        // emulate we're in an event loop…
-        self::$registry = [];
-        $this->assertNull(self::fetchState("foobar"));
+        $this->assertNull($this->registry->fetchState("foobar"));
     }
 
     /**
@@ -43,13 +23,10 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function fetchesStoredValue($value)
     {
-        // emulate we're in an event loop…
-        self::$registry = [];
+        $this->assertNull($this->registry->fetchState("foobar"));
+        $this->registry->storeState("foobar", $value);
 
-        $this->assertNull(self::fetchState("foobar"));
-        self::storeState("foobar", $value);
-
-        $this->assertSame($value, self::fetchState("foobar"));
+        $this->assertSame($value, $this->registry->fetchState("foobar"));
     }
 
     public function provideValues()


### PR DESCRIPTION
This PR supersedes #64 and addresses the issue raised in https://github.com/async-interop/event-loop/pull/65#discussion_r64792576.

Instead of being used by `Loop`, `Registry` should now be used by classes implementing `Driver` so each driver object contains state storage. While this is a violation of SRP, I believe this is the best compromise for associating data with a particular loop.
