### PR TITLE
Specify when exactly a watchers callbacks may start to be called

### DIFF
--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -107,6 +107,8 @@ interface Driver
 
     /**
      * Enable a watcher.
+     * 
+     * Watchers (enabling or new watchers) MUST immediately be marked as enabled, but only be activated (i.e. callbacks can be called) right before the next tick. Callbacks of watchers MUST not be called in the tick they were enabled.
      *
      * @param string $watcherId The watcher identifier.
      *


### PR DESCRIPTION
Delaying activation of watchers to the next tick guarantees consistent behavior between all implementations.

Additionally it eliminates the following problem:
- Two defer()'s are set up with the first one immediately disabled
- Second defer()'s callback is called and enables the first defer()'s watcher
- Executes defer() in same tick or next tick?

If the answer is same tick, what happens in the following scenario:
- An immediately disabled defer() and a delay($msDelay = 0) are set up
- The delay()'s callback enables the defer()'s watcher
- Executes defer() callback in same tick or next tick?
  Doing it in same tick violates the requirement that defers are called before any other watchers in the same tick.

We get similar problems with e.g. delay() and repeat() (if their timer all expired now, but we require order to be preserved).

Thus we need to pretty much delay the activation of enable() to the next tick to avoid potential ambiguity or different behaviors depending on when exactly the enable() or watcher registration happened.
