### PR TITLE
Add a warning/implementation note about installing handlers for a same signal on different loops

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -199,6 +199,9 @@ final class Loop
     /**
      * Execute a callback when a signal is received.
      *
+     * WARNING: Installing a handler on the same signal on different scopes of event loop execution is
+     *          undefined behavior and may break things arbitrarily.
+     *
      * @param int $signo The signal number to monitor.
      * @param callable(string $watcherId, int $signo, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -100,6 +100,10 @@ interface Driver
      *
      * Multiple watchers on the same signal may be executed in any order.
      *
+     * NOTE: Installing a same signal on different instances of this interface is deemed undefined behavior.
+     *       Implementations may try to detect this, if possible, but are not required to.
+     *       This is due to technical limitations of the signals being registered globally per process.
+     *
      * @param int $signo The signal number to monitor.
      * @param callable(string $watcherId, int $signo, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.


### PR DESCRIPTION
This needs to be undefined behavior as we do not have the possibilities in PHP (i.e. the language and functions don't give us the power) to distinguish properly whether a signal is already installed or not
Also, when we try to set a handler for a signal we've already installed a signal elsewhere, the second onSignal() call will lead implementations to override the original handler (on the system level, with signal()/sigaction())
Ultimately some extensions just flat out emit a warning in that case (e.g. libev).

Thus, we cannot control what happens and hence this needs to be specified as undefined behavior.

Also see issues we encountered with https://github.com/async-interop/event-loop-test/blob/d6c299a4485e0ebb731a8d239ccaff346a3fe531/src/Test.php#L943 … Turned out we just were even unable to make this test work _in a controlled way_.
