### PR TITLE
Use parallel-lint for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ cache:
 
 install:
   - composer install
-  - composer show
+  - composer show -t
 
 script:
-  - find -name "*.php" -not -path "./vendor/*" -print0 | xargs -n 1 -0 php -l
-  - $(php -r 'if (PHP_MAJOR_VERSION >= 7) echo "phpdbg -qrr"; else echo "php";') vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
+  - php vendor/bin/parallel-lint --exclude vendor .
+  - php vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,9 @@
         "php": ">=5.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4|^5"
+        "phpunit/phpunit": "^4|^5",
+        "jakub-onderka/php-parallel-lint": "^0.9.2",
+        "jakub-onderka/php-console-highlighter": "^0.3.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Mostly for better output, build time is probably slower, because of an additional dependency. Also doesn't abort on first failure.