### PR TITLE
Rename Loop::info to Loop::getInfo

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -414,7 +414,7 @@ final class Loop
      * Implementations MAY optionally add more information in the array but at minimum the above `key => value` format
      * MUST always be provided.
      *
-     * @return array
+     * @return array Statistics about the loop in the described format.
      */
     public static function getInfo()
     {

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -416,10 +416,10 @@ final class Loop
      *
      * @return array
      */
-    public static function info()
+    public static function getInfo()
     {
         $driver = self::$driver ?: self::get();
-        return $driver->info();
+        return $driver->getInfo();
     }
 
     /**

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -270,7 +270,7 @@ abstract class Driver
      *
      * @return array
      */
-    abstract public function info();
+    abstract public function getInfo();
 
     /**
      * Get the underlying loop handle.

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -268,7 +268,7 @@ abstract class Driver
      * Implementations MAY optionally add more information in the array but at minimum the above `key => value` format
      * MUST always be provided.
      *
-     * @return array
+     * @return array Statistics about the loop in the described format.
      */
     abstract public function getInfo();
 

--- a/test/DummyDriver.php
+++ b/test/DummyDriver.php
@@ -43,6 +43,6 @@ class DummyDriver extends Driver
     public function cancel($watcherId) {}
     public function reference($watcherId) {}
     public function unreference($watcherId) {}
-    public function info() {}
+    public function getInfo() {}
     public function getHandle() {}
 }


### PR DESCRIPTION
We use `get` for all other similar methods, too. Closes #102.