### PR TITLE
Enforce unique-per-process watcher identifiers

### DIFF
--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -356,7 +356,7 @@ abstract class Driver
             throw new \InvalidArgumentException('A non-string was provided as a watcher identifier.');
         }
 
-        if ($this->driverId !== explode('-', $watcherId, 2)[0]) {
+        if ($this->driverId !== \explode('-', $watcherId, 2)[0]) {
             throw new InvalidWatcherException($watcherId);
         }
     }


### PR DESCRIPTION
As discussed briefly in #126, this PR proposes enforcing that watcher identifiers are unique-per-process, instead of just unique-per-driver instance. I believe that this will eliminate the potential for some scary and confusing bugs where multiple driver instances are used within a single process and watcher identifiers are unknowingly, possibly silently, passed to the wrong drivers.

I took an approach which allows loop implementations to define their own "local" watcher identifiers, which must be prepared using the provided method _getGlobalWatcherId()_ before being returned to clients. If it isn't really necessary for loop implementations to define their own watcher identifiers then we could potentially simplify further by generating the watcher identifiers incrementally in the abstract `Driver` class. This would have the added benefit of allowing us to distinguish between _already removed_ watcher identifiers and _invalid_ (never returned by the driver) identifiers.

If some of you loop implementors could give feedback that would be appreciated; obviously you're more qualified than I am to know whether there are problems with this approach.

@bwoebi 

Edit: I'll add tests if people like the feature.