### PR TITLE
watchers → enabled_watchers in getInfo

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -402,13 +402,13 @@ final class Loop
      * The returned array MUST contain the following data describing the driver's currently registered watchers:
      *
      *     [
-     *         "defer"         => ["enabled" => int, "disabled" => int],
-     *         "delay"         => ["enabled" => int, "disabled" => int],
-     *         "repeat"        => ["enabled" => int, "disabled" => int],
-     *         "on_readable"   => ["enabled" => int, "disabled" => int],
-     *         "on_writable"   => ["enabled" => int, "disabled" => int],
-     *         "on_signal"     => ["enabled" => int, "disabled" => int],
-     *         "watchers"      => ["referenced" => int, "unreferenced" => int],
+     *         "defer"            => ["enabled" => int, "disabled" => int],
+     *         "delay"            => ["enabled" => int, "disabled" => int],
+     *         "repeat"           => ["enabled" => int, "disabled" => int],
+     *         "on_readable"      => ["enabled" => int, "disabled" => int],
+     *         "on_writable"      => ["enabled" => int, "disabled" => int],
+     *         "on_signal"        => ["enabled" => int, "disabled" => int],
+     *         "enabled_watchers" => ["referenced" => int, "unreferenced" => int],
      *     ];
      *
      * Implementations MAY optionally add more information in the array but at minimum the above `key => value` format

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -258,13 +258,13 @@ abstract class Driver
      * The returned array MUST contain the following data describing the driver's currently registered watchers:
      *
      *     [
-     *         "defer"         => ["enabled" => int, "disabled" => int],
-     *         "delay"         => ["enabled" => int, "disabled" => int],
-     *         "repeat"        => ["enabled" => int, "disabled" => int],
-     *         "on_readable"   => ["enabled" => int, "disabled" => int],
-     *         "on_writable"   => ["enabled" => int, "disabled" => int],
-     *         "on_signal"     => ["enabled" => int, "disabled" => int],
-     *         "watchers"      => ["referenced" => int, "unreferenced" => int],
+     *         "defer"            => ["enabled" => int, "disabled" => int],
+     *         "delay"            => ["enabled" => int, "disabled" => int],
+     *         "repeat"           => ["enabled" => int, "disabled" => int],
+     *         "on_readable"      => ["enabled" => int, "disabled" => int],
+     *         "on_writable"      => ["enabled" => int, "disabled" => int],
+     *         "on_signal"        => ["enabled" => int, "disabled" => int],
+     *         "enabled_watchers" => ["referenced" => int, "unreferenced" => int],
      *     ];
      *
      * Implementations MAY optionally add more information in the array but at minimum the above `key => value` format


### PR DESCRIPTION
This ensures it's clear which info is returned. I could have added another sentence to the docblock instead, but I think this makes it more obvious when consuming the code, too.

In general, I think that we should be careful with allowing extension here, as it limits us in adding more specified keys, such as `"disabled_watchers"`.