### PR TITLE
Composer: Add API virtual package and require an implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "async-interop/event-loop-api": "0.1"
     },
     "suggest": {
-        "async-interop/event-loop-implementation": "A loop implementation is needed in order to run the loop."
+        "async-interop/event-loop-implementation": "A loop implementation is required in order to run a loop."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "jakub-onderka/php-console-highlighter": "^0.3.2"
     },
+    "provide": {
+        "async-interop/event-loop-api": "0.1"
+    },
     "autoload": {
         "psr-4": {
             "AsyncInterop\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "keywords": ["event", "loop", "async", "interop"],
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0",
-        "async-interop/event-loop-implementation": "^0.5"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4|^5",
@@ -14,6 +13,9 @@
     },
     "provide": {
         "async-interop/event-loop-api": "0.1"
+    },
+    "suggest": {
+        "async-interop/event-loop-implementation": "A loop implementation is needed in order to run the loop."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "keywords": ["event", "loop", "async", "interop"],
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=5.5.0",
+        "async-interop/event-loop-implementation": "^0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4|^5",


### PR DESCRIPTION
Resolves #129.

There's a potential issue here: Travis is now going to require a compatible `event-loop-implementation` in order to run the tests for `event-loop`. To solve this, perhaps we could create an `event-loop-dummy-implementation` repo in `async-interop`, _not_ add it to Packagist so it's not pulled in elsewhere, move `tests\DummyDriver.php` to that new repo, and add the following to the `event-loop` composer.json file:

```json
{
    "repositories": [ { "type": "git", "url": "https://github.com/async-interop/event-loop-dummy-implementation.git" } ]
}
```

Thoughts?