### PR TITLE
Enforce unique-per-process watcher identifiers

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -295,11 +295,14 @@ final class Loop
      * Cancel a watcher.
      *
      * This will detatch the event loop from all resources that are associated to the watcher. After this operation the
-     * watcher is permanently invalid. Calling this function MUST NOT fail, even if passed an invalid watcher.
+     * watcher is permanently invalid. Calling this function MUST NOT fail if the passed watcher was issued by this
+     * driver but is no longer valid.
      *
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException If the watcher identifier is invalid.
      */
     public static function cancel($watcherId)
     {

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -295,14 +295,14 @@ final class Loop
      * Cancel a watcher.
      *
      * This will detatch the event loop from all resources that are associated to the watcher. After this operation the
-     * watcher is permanently invalid. Calling this function MUST NOT fail if the passed watcher was issued by this
-     * driver but is no longer valid.
+     * watcher is permanently invalid. Calling this function MUST NOT fail if the passed watcher was issued by the
+     * current driver but is no longer valid.
      *
      * @param string $watcherId The watcher identifier.
      *
      * @return void
      *
-     * @throws InvalidWatcherException If the watcher identifier is invalid.
+     * @throws InvalidWatcherException If the watcher identifier does not belong to the current driver.
      */
     public static function cancel($watcherId)
     {

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -17,12 +17,12 @@ abstract class Driver
     /**
      * @var string
      */
-    private $driverId;
+    private $watcherIdPrefix;
 
     /**
      * @var string
      */
-    private $nextWatcherId = 'a';
+    private $nextWatcherId;
 
     /**
      * @var array
@@ -34,7 +34,8 @@ abstract class Driver
      */
     public function __construct()
     {
-        $this->driverId = self::$nextDriverId++ . '-';
+        $this->watcherIdPrefix = self::$nextDriverId++ . '-';
+        $this->nextWatcherId = "{$this->watcherIdPrefix}a";
     }
 
     /**
@@ -322,7 +323,7 @@ abstract class Driver
      */
     final protected function createWatcherId()
     {
-        return $this->driverId . $this->nextWatcherId++;
+        return $this->nextWatcherId++;
     }
 
     /**
@@ -338,9 +339,9 @@ abstract class Driver
      *
      * @throws InvalidWatcherException
      */
-    final protected function validateWatcherId($watcherId, bool $mustThrow)
+    final protected function validateWatcherId($watcherId, $mustThrow)
     {
-        if (0 !== \strpos($watcherId, $this->driverId)) {
+        if (0 !== \strpos($watcherId, $this->watcherIdPrefix)) {
             // the watcher was created by a different driver
             throw new InvalidWatcherException($watcherId, 'A watcher was passed to the wrong driver.');
         }

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -326,7 +326,7 @@ abstract class Driver
     }
 
     /**
-     * Validate a watcher identifier which was passed to the driver by a client.
+     * Validate a watcher identifier which has been passed to the driver by a client.
      *
      * The driver MUST call this method when it is provided with a watcher identifier which it does not recognise. The
      * driver SHOULD NOT call this method every time it receives a watcher identifier, as doing so would be relatively
@@ -339,7 +339,11 @@ abstract class Driver
     final protected function validateWatcherId($watcherId)
     {
         if (0 !== \strpos($watcherId, $this->watcherIdPrefix)) {
-            throw new InvalidWatcherException($watcherId, 'A watcher was passed to the wrong driver.');
+            throw new InvalidWatcherException(
+                $watcherId,
+                "Watcher '{$watcherId}' has been passed to the wrong driver. Watchers passed to this driver must " .
+                "start with '{$this->watcherIdPrefix}'."
+            );
         }
     }
 }

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -180,12 +180,14 @@ abstract class Driver
      * Cancel a watcher.
      *
      * This will detach the event loop from all resources that are associated to the watcher. After this operation the
-     * watcher is permanently invalid. Calling this function MUST NOT fail even if the passed watcher was issued by this
+     * watcher is permanently invalid. Calling this function MUST NOT fail if the passed watcher was issued by this
      * driver but is no longer valid.
      *
      * @param string $watcherId The watcher identifier.
      *
      * @return void
+     *
+     * @throws InvalidWatcherException If the watcher identifier is invalid.
      */
     abstract public function cancel($watcherId);
 

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -17,7 +17,7 @@ abstract class Driver
     /**
      * @var string
      */
-    private $driverId;
+    private $watcherIdPrefix;
 
     /**
      * @var string
@@ -34,7 +34,7 @@ abstract class Driver
      */
     public function __construct()
     {
-        $this->driverId = self::$nextDriverId++ . '-';
+        $this->watcherIdPrefix = self::$nextDriverId++ . '-';
     }
 
     /**
@@ -322,7 +322,7 @@ abstract class Driver
      */
     final protected function createWatcherId()
     {
-        return $this->driverId . $this->nextWatcherId++;
+        return $this->watcherIdPrefix . $this->nextWatcherId++;
     }
 
     /**
@@ -338,9 +338,9 @@ abstract class Driver
      *
      * @throws InvalidWatcherException
      */
-    final protected function validateWatcherId($watcherId, bool $mustThrow)
+    final protected function validateWatcherId($watcherId, $mustThrow)
     {
-        if (0 !== \strpos($watcherId, $this->driverId)) {
+        if (0 !== \strpos($watcherId, $this->watcherIdPrefix)) {
             // the watcher was created by a different driver
             throw new InvalidWatcherException($watcherId, 'A watcher was passed to the wrong driver.');
         }

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -17,12 +17,12 @@ abstract class Driver
     /**
      * @var string
      */
-    private $watcherIdPrefix;
+    private $driverId;
 
     /**
      * @var string
      */
-    private $nextWatcherId;
+    private $nextWatcherId = 'a';
 
     /**
      * @var array
@@ -34,8 +34,7 @@ abstract class Driver
      */
     public function __construct()
     {
-        $this->watcherIdPrefix = self::$nextDriverId++ . '-';
-        $this->nextWatcherId = "{$this->watcherIdPrefix}a";
+        $this->driverId = self::$nextDriverId++ . '-';
     }
 
     /**
@@ -323,7 +322,7 @@ abstract class Driver
      */
     final protected function createWatcherId()
     {
-        return $this->nextWatcherId++;
+        return $this->driverId . $this->nextWatcherId++;
     }
 
     /**
@@ -339,9 +338,9 @@ abstract class Driver
      *
      * @throws InvalidWatcherException
      */
-    final protected function validateWatcherId($watcherId, $mustThrow)
+    final protected function validateWatcherId($watcherId, bool $mustThrow)
     {
-        if (0 !== \strpos($watcherId, $this->watcherIdPrefix)) {
+        if (0 !== \strpos($watcherId, $this->driverId)) {
             // the watcher was created by a different driver
             throw new InvalidWatcherException($watcherId, 'A watcher was passed to the wrong driver.');
         }

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -328,25 +328,18 @@ abstract class Driver
     /**
      * Validate a watcher identifier which was passed to the driver by a client.
      *
-     * The driver SHOULD call this method when it is provided with a watcher identifier which it does not recognise. The
+     * The driver MUST call this method when it is provided with a watcher identifier which it does not recognise. The
      * driver SHOULD NOT call this method every time it receives a watcher identifier, as doing so would be relatively
      * expensive and is not typically necessary.
      *
      * @param string $watcherId The watcher identifier.
-     * @param bool $mustThrow Whether the method MUST throw. For example, if `enable()` was called with an unrecognised
-     * watcher identifier then this should be set to `true`, but if `cancel()` was called it should be set to `false`.
      *
-     * @throws InvalidWatcherException
+     * @throws InvalidWatcherException If the watcher identifier does not belong to this driver.
      */
-    final protected function validateWatcherId($watcherId, $mustThrow)
+    final protected function validateWatcherId($watcherId)
     {
         if (0 !== \strpos($watcherId, $this->watcherIdPrefix)) {
-            // the watcher was created by a different driver
             throw new InvalidWatcherException($watcherId, 'A watcher was passed to the wrong driver.');
-        }
-
-        if ($mustThrow) {
-            throw new InvalidWatcherException($watcherId);
         }
     }
 }

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -195,7 +195,7 @@ abstract class Driver
      *
      * @return void
      *
-     * @throws InvalidWatcherException If the watcher identifier is invalid.
+     * @throws InvalidWatcherException If the watcher identifier does not belong to this driver.
      */
     abstract public function cancel($watcherId);
 


### PR DESCRIPTION
This PR aims to enforce unique-per-process watcher identifiers. It does so in a relatively cheap way, adding a single function call per watcher created, and also provides a more expensive validation method which drivers should only call when they do not recognise a watcher identifier. This validation method is able to distinguish between the following error cases:
- ~Watcher identifier invalid~
- Watcher identifier passed to wrong driver instance
- ~Watcher identifier no longer valid~

Edit: The PR is now more efficient but provides less fine-grained errors.