### PR TITLE
Safe execute

### DIFF
--- a/test/DummyDriver.php
+++ b/test/DummyDriver.php
@@ -6,7 +6,7 @@ use AsyncInterop\Loop\Driver;
 
 class DummyDriver extends Driver
 {
-    public $defers;
+    public $defers = [];
     public $handler;
     public static $id = "a";
 

--- a/test/LoopTest.php
+++ b/test/LoopTest.php
@@ -34,13 +34,13 @@ class LoopTest extends \PHPUnit_Framework_TestCase
         $driver2 = new DummyDriver;
 
         Loop::execute(function () use ($driver1, $driver2) {
-            $this->assertSame($driver1, Loop::get());
+            $this->assertSame($driver1, Loop::getDriver());
 
             Loop::execute(function () use ($driver2) {
-                $this->assertSame($driver2, Loop::get());
+                $this->assertSame($driver2, Loop::getDriver());
             }, $driver2);
 
-            $this->assertSame($driver1, Loop::get());
+            $this->assertSame($driver1, Loop::getDriver());
         }, $driver1);
     }
 }


### PR DESCRIPTION
This ensures we have a safe execute context again and removes the side effect of `setFactory`. I think we could even allow `setFactory` when running now.

This has the slight disadvantage for sync applications that they have to wrap their setup code in `Loop::execute`, too.