### PR TITLE
Resolve #142 by adding a run() method

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -89,14 +89,10 @@ final class Loop
      *
      * @return void
      *
-     * @see \AsyncInterop\Loop::run()
+     * @see \AsyncInterop\Loop\Driver::run()
      */
     public static function run()
     {
-        if (self::$level > 0) {
-            throw new \RuntimeException("The loop can only be run while not yet running.");
-        }
-
         $driver = self::$driver ?: self::get();
         self::$level++;
 
@@ -455,10 +451,3 @@ final class Loop
         // intentionally left blank
     }
 }
-
-// Reset the $level in order to be able to use ::run() inside a shutdown handler
-$f = function()
-{
-    self::$level = 0;
-};
-register_shutdown_function($f->bindTo(null, Loop::class));


### PR DESCRIPTION
As per: https://github.com/async-interop/event-loop/pull/142#issuecomment-275927251

Also adding a shutdown function at the end in order to ensure that the loop level will be correct (i.e. people able to use Loop::run() in a shutdown function).

\cc @davidwdan @trowski @mbonneau