### PR TITLE
Remove setFactory() side-effect and add resetDriver()

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -271,9 +271,8 @@ final class Loop
     /**
      * Enable a watcher.
      *
-     * Watchers (enabling or new watchers) MUST immediately be marked as enabled, but only be activated (i.e. callbacks
-     * can be called) right before the next tick. Callbacks of watchers MUST not be called in the tick they were
-     * enabled.
+     * Watchers MUST immediately be marked as enabled, but only be activated (i.e. callbacks can be called) right before
+     * the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
      *
      * @param string $watcherId The watcher identifier.
      *

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -148,8 +148,11 @@ final class Loop
     /**
      * Defer the execution of a callback.
      *
-     * The deferred callable MUST be executed in the next tick of the event loop and before any other type of watcher.
-     * Order of enabling MUST be preserved when executing the callbacks.
+     * The deferred callable MUST be executed before any other type of watcher in a tick. Order of enabling MUST be
+     * preserved when executing the callbacks.
+     *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
      *
      * @param callable(string $watcherId, mixed $data) $callback The callback to defer. The `$watcherId` will be
      *     invalidated before the callback call.
@@ -168,6 +171,9 @@ final class Loop
      *
      * The delay is a minimum and approximate, accuracy is not guaranteed. Order of calls MUST be determined by which
      * timers expire first, but timers with the same expiration time MAY be executed in any order.
+     *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
      *
      * @param int $delay The amount of time, in milliseconds, to delay the execution for.
      * @param callable(string $watcherId, mixed $data) $callback The callback to delay. The `$watcherId` will be
@@ -188,6 +194,9 @@ final class Loop
      * The interval between executions is a minimum and approximate, accuracy is not guaranteed. Order of calls MUST be
      * determined by which timers expire first, but timers with the same expiration time MAY be executed in any order.
      * The first execution is scheduled after the first interval period.
+     *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
      *
      * @param int $interval The time interval, in milliseconds, to wait between executions.
      * @param callable(string $watcherId, mixed $data) $callback The callback to repeat.
@@ -211,6 +220,9 @@ final class Loop
      *
      * Multiple watchers on the same stream MAY be executed in any order.
      *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
+     *
      * @param resource $stream The stream to monitor.
      * @param callable(string $watcherId, resource $stream, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the `$data` parameter.
@@ -233,6 +245,9 @@ final class Loop
      *
      * Multiple watchers on the same stream MAY be executed in any order.
      *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
+     *
      * @param resource $stream The stream to monitor.
      * @param callable(string $watcherId, resource $stream, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the `$data` parameter.
@@ -254,6 +269,9 @@ final class Loop
      *
      * Multiple watchers on the same signal MAY be executed in any order.
      *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
+     *
      * @param int $signo The signal number to monitor.
      * @param callable(string $watcherId, int $signo, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
@@ -269,7 +287,7 @@ final class Loop
     }
 
     /**
-     * Enable a watcher.
+     * Enable a watcher to be active starting in the next tick.
      *
      * Watchers MUST immediately be marked as enabled, but only be activated (i.e. callbacks can be called) right before
      * the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
@@ -287,7 +305,10 @@ final class Loop
     }
 
     /**
-     * Disable a watcher.
+     * Disable a watcher immediately.
+     *
+     * A watcher MUST be disabled immediately, e.g. if a defer watcher disables a later defer watcher, the second defer
+     * watcher isn't executed in this tick.
      *
      * Disabling a watcher MUST NOT invalidate the watcher. Calling this function MUST NOT fail, even if passed an
      * invalid watcher.

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -38,9 +38,9 @@ final class Loop
      * The factory will be invoked if none is passed to `Loop::execute`. A default driver will be created to
      * support synchronous waits in traditional applications.
      *
-     * @param DriverFactory $factory New factory to replace the previous one.
+     * @param DriverFactory|null $factory New factory to replace the previous one.
      */
-    public static function setFactory(DriverFactory $factory)
+    public static function setFactory(DriverFactory $factory = null)
     {
         if (self::$level > 0) {
             throw new \RuntimeException("Setting a new factory while running isn't allowed!");

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -38,18 +38,15 @@ final class Loop
      * The factory will be invoked if none is passed to `Loop::execute`. A default driver will be created to
      * support synchronous waits in traditional applications.
      *
-     * @param DriverFactory|null $factory New factory to replace the previous one.
+     * @param DriverFactory $factory New factory to replace the previous one.
      */
-    public static function setFactory(DriverFactory $factory = null)
+    public static function setFactory(DriverFactory $factory)
     {
         if (self::$level > 0) {
             throw new \RuntimeException("Setting a new factory while running isn't allowed!");
         }
 
         self::$factory = $factory;
-
-        // reset it here, it will be actually instantiated inside execute() or get()
-        self::$driver = null;
     }
 
     /**
@@ -103,6 +100,21 @@ final class Loop
         }
 
         return $driver;
+    }
+
+    /**
+     * Resets the driver (sets the internal driver instance to null), forcing the creation of a new driver instance.
+     * This method can only be called if the loop is not running.
+     *
+     * @throws \RuntimeException If the loop is running.
+     */
+    public static function resetDriver()
+    {
+        if (self::$level > 0) {
+            throw new \RuntimeException("Resetting the driver while running isn't allowed!");
+        }
+
+        self::$driver = null;
     }
 
     /**

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -47,8 +47,11 @@ abstract class Driver
     /**
      * Defer the execution of a callback.
      *
-     * The deferred callable MUST be executed in the next tick of the event loop and before any other type of watcher.
-     * Order of enabling MUST be preserved when executing the callbacks.
+     * The deferred callable MUST be executed before any other type of watcher in a tick. Order of enabling MUST be
+     * preserved when executing the callbacks.
+     *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
      *
      * @param callable(string $watcherId, mixed $data) $callback The callback to defer. The `$watcherId` will be
      *     invalidated before the callback call.
@@ -63,6 +66,9 @@ abstract class Driver
      *
      * The delay is a minimum and approximate, accuracy is not guaranteed. Order of calls MUST be determined by which
      * timers expire first, but timers with the same expiration time MAY be executed in any order.
+     *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
      *
      * @param int $delay The amount of time, in milliseconds, to delay the execution for.
      * @param callable(string $watcherId, mixed $data) $callback The callback to delay. The `$watcherId` will be
@@ -79,6 +85,9 @@ abstract class Driver
      * The interval between executions is a minimum and approximate, accuracy is not guaranteed. Order of calls MUST be
      * determined by which timers expire first, but timers with the same expiration time MAY be executed in any order.
      * The first execution is scheduled after the first interval period.
+     *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
      *
      * @param int $interval The time interval, in milliseconds, to wait between executions.
      * @param callable(string $watcherId, mixed $data) $callback The callback to repeat.
@@ -98,6 +107,9 @@ abstract class Driver
      *
      * Multiple watchers on the same stream MAY be executed in any order.
      *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
+     *
      * @param resource $stream The stream to monitor.
      * @param callable(string $watcherId, resource $stream, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the `$data` parameter.
@@ -116,6 +128,9 @@ abstract class Driver
      *
      * Multiple watchers on the same stream MAY be executed in any order.
      *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
+     *
      * @param resource $stream The stream to monitor.
      * @param callable(string $watcherId, resource $stream, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the `$data` parameter.
@@ -133,6 +148,9 @@ abstract class Driver
      *
      * Multiple watchers on the same signal MAY be executed in any order.
      *
+     * The created watcher MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
+     * right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
+     *
      * @param int $signo The signal number to monitor.
      * @param callable(string $watcherId, int $signo, mixed $data) $callback The callback to execute.
      * @param mixed $data Arbitrary data given to the callback function as the $data parameter.
@@ -144,7 +162,7 @@ abstract class Driver
     abstract public function onSignal($signo, callable $callback, $data = null);
 
     /**
-     * Enable a watcher.
+     * Enable a watcher to be active starting in the next tick.
      *
      * Watchers MUST immediately be marked as enabled, but only be activated (i.e. callbacks can be called) right before
      * the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
@@ -158,7 +176,10 @@ abstract class Driver
     abstract public function enable($watcherId);
 
     /**
-     * Disable a watcher.
+     * Disable a watcher immediately.
+     *
+     * A watcher MUST be disabled immediately, e.g. if a defer watcher disables a later defer watcher, the second defer
+     * watcher isn't executed in this tick.
      *
      * Disabling a watcher MUST NOT invalidate the watcher. Calling this function MUST NOT fail, even if passed an
      * invalid watcher.

--- a/src/Loop/Driver.php
+++ b/src/Loop/Driver.php
@@ -5,7 +5,10 @@ namespace AsyncInterop\Loop;
 /**
  * Event loop driver which implements all basic operations to allow interoperability.
  *
- * Registered callbacks MUST NOT be called from a file with strict types enabled (`declare(strict_types=1)`).
+ * Watchers (enabled or new watchers) MUST immediately be marked as enabled, but only be activated (i.e. callbacks can
+ * be called) right before the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
+ *
+ * All registered callbacks MUST NOT be called from a file with strict types enabled (`declare(strict_types=1)`).
  */
 abstract class Driver
 {
@@ -143,9 +146,8 @@ abstract class Driver
     /**
      * Enable a watcher.
      *
-     * Watchers (enabling or new watchers) MUST immediately be marked as enabled, but only be activated (i.e. callbacks
-     * can be called) right before the next tick. Callbacks of watchers MUST not be called in the tick they were
-     * enabled.
+     * Watchers MUST immediately be marked as enabled, but only be activated (i.e. callbacks can be called) right before
+     * the next tick. Callbacks of watchers MUST NOT be called in the tick they were enabled.
      *
      * @param string $watcherId The watcher identifier.
      *

--- a/test/LoopTest.php
+++ b/test/LoopTest.php
@@ -6,10 +6,6 @@ use AsyncInterop\Loop;
 
 class LoopTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp() {
-        Loop::setFactory(null);
-    }
-
     /**
      * @test
      * @expectedException \RuntimeException
@@ -42,5 +38,38 @@ class LoopTest extends \PHPUnit_Framework_TestCase
 
             $this->assertSame($driver1, Loop::get());
         }, $driver1);
+    }
+
+    /** @test */
+    public function resetDriver() {
+        $factory = $this->getMockBuilder(Loop\DriverFactory::class)->getMock();
+        $factory->method("create")->willReturnCallback(function () {
+            return new DummyDriver;
+        });
+
+        Loop::setFactory($factory);
+
+        $driver1 = Loop::get();
+        Loop::resetDriver();
+        $driver2 = Loop::get();
+        $this->assertNotSame($driver1, $driver2);
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Resetting the driver while running isn't allowed
+     */
+    public function resetDriverDuringRunning() {
+        $driver = new DummyDriver;
+
+        $factory = $this->getMockBuilder(Loop\DriverFactory::class)->getMock();
+        $factory->method("create")->willReturn($driver);
+
+        Loop::setFactory($factory);
+
+        Loop::execute(function () use ($factory) {
+            Loop::resetDriver();
+        });
     }
 }


### PR DESCRIPTION
Invoking `Loop::setFactory()` removes the active `Driver` instance as a side-effect. This PR removes this side-effect and requires a new `DriverFactory` instance be passed to `Loop::setFactory()` (instead of being nullable).

To remove the current `Driver` instance and force a new one to be created, a `Loop::resetDriver()` method is added. This method cannot be invoked while the loop is running.